### PR TITLE
Fixed examples to run on macos

### DIFF
--- a/examples/egui_ash_simple/main.rs
+++ b/examples/egui_ash_simple/main.rs
@@ -191,6 +191,16 @@ impl MyAppCreator {
             let name = ext.as_ptr();
             extension_names.push(name);
         }
+         #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+        }
+        let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+            vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+        } else {
+            vk::InstanceCreateFlags::default()
+        };
         let raw_layer_names = Self::VALIDATION
             .iter()
             .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -202,6 +212,7 @@ impl MyAppCreator {
         let instance_create_info = vk::InstanceCreateInfo::builder()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
+            .flags(create_flags)
             .enabled_extension_names(&extension_names);
         let instance_create_info = if Self::ENABLE_VALIDATION_LAYERS {
             instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/egui_ash_vulkan/main.rs
+++ b/examples/egui_ash_vulkan/main.rs
@@ -195,6 +195,16 @@ impl MyAppCreator {
             let name = ext.as_ptr();
             extension_names.push(name);
         }
+         #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+        }
+        let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+            vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+        } else {
+            vk::InstanceCreateFlags::default()
+        };
         let raw_layer_names = Self::VALIDATION
             .iter()
             .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -206,6 +216,7 @@ impl MyAppCreator {
         let instance_create_info = vk::InstanceCreateInfo::builder()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
+            .flags(create_flags)
             .enabled_extension_names(&extension_names);
         let instance_create_info = if Self::ENABLE_VALIDATION_LAYERS {
             instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/images/main.rs
+++ b/examples/images/main.rs
@@ -124,6 +124,16 @@ impl MyAppCreator {
             let name = ext.as_ptr();
             extension_names.push(name);
         }
+         #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+        }
+        let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+            vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+        } else {
+            vk::InstanceCreateFlags::default()
+        };
         let raw_layer_names = Self::VALIDATION
             .iter()
             .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -135,6 +145,7 @@ impl MyAppCreator {
         let instance_create_info = vk::InstanceCreateInfo::builder()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
+            .flags(create_flags)
             .enabled_extension_names(&extension_names);
         let instance_create_info = if Self::ENABLE_VALIDATION_LAYERS {
             instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/multi_viewports/vkutils.rs
+++ b/examples/multi_viewports/vkutils.rs
@@ -73,6 +73,16 @@ pub fn create_instance(
         let name = ext.as_ptr();
         extension_names.push(name);
     }
+     #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+        extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+    }
+    let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+        vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+    } else {
+        vk::InstanceCreateFlags::default()
+    };
     let raw_layer_names = VALIDATION
         .iter()
         .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -84,6 +94,7 @@ pub fn create_instance(
     let instance_create_info = vk::InstanceCreateInfo::builder()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
+        .flags(create_flags)
         .enabled_extension_names(&extension_names);
     let instance_create_info = if ENABLE_VALIDATION_LAYERS {
         instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/native_image/main.rs
+++ b/examples/native_image/main.rs
@@ -152,6 +152,16 @@ impl MyAppCreator {
             let name = ext.as_ptr();
             extension_names.push(name);
         }
+         #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+        }
+        let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+            vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+        } else {
+            vk::InstanceCreateFlags::default()
+        };
         let raw_layer_names = Self::VALIDATION
             .iter()
             .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -163,6 +173,7 @@ impl MyAppCreator {
         let instance_create_info = vk::InstanceCreateInfo::builder()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
+            .flags(create_flags)
             .enabled_extension_names(&extension_names);
         let instance_create_info = if Self::ENABLE_VALIDATION_LAYERS {
             instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/scene_view/vkutils.rs
+++ b/examples/scene_view/vkutils.rs
@@ -73,6 +73,17 @@ pub fn create_instance(
         let name = ext.as_ptr();
         extension_names.push(name);
     }
+     #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+        extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+    }
+    let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+        vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+    } else {
+        vk::InstanceCreateFlags::default()
+    };
+
     let raw_layer_names = VALIDATION
         .iter()
         .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -84,6 +95,7 @@ pub fn create_instance(
     let instance_create_info = vk::InstanceCreateInfo::builder()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
+        .flags(create_flags)
         .enabled_extension_names(&extension_names);
     let instance_create_info = if ENABLE_VALIDATION_LAYERS {
         instance_create_info.enabled_layer_names(&layer_names)

--- a/examples/tiles/vkutils.rs
+++ b/examples/tiles/vkutils.rs
@@ -73,6 +73,17 @@ pub fn create_instance(
         let name = ext.as_ptr();
         extension_names.push(name);
     }
+     #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
+        extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+    }
+    let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
+        vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+    } else {
+        vk::InstanceCreateFlags::default()
+    };
+
     let raw_layer_names = VALIDATION
         .iter()
         .map(|l| std::ffi::CString::new(*l).unwrap())
@@ -84,6 +95,7 @@ pub fn create_instance(
     let instance_create_info = vk::InstanceCreateInfo::builder()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
+        .flags(create_flags)
         .enabled_extension_names(&extension_names);
     let instance_create_info = if ENABLE_VALIDATION_LAYERS {
         instance_create_info.enabled_layer_names(&layer_names)


### PR DESCRIPTION
On MacOS all examples fail with a message of

> Found drivers that contain devices which support the portability subset, but the instance does not enumerate portability drivers! Applications that wish to enumerate portability drivers must set the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit in the VkInstanceCreateInfo flags and enable the VK_KHR_portability_enumeration instance extension.

![Screenshot 2024-03-19 at 3 36 22 PM](https://github.com/MatchaChoco010/egui-ash/assets/18584095/06465c3d-635d-450f-8e30-6967b2a1e0a9)


This PR resolves that issue for all examples on MacOS