### PR TITLE
[WIP] Update to latest ash, egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,17 @@ documentation = "https://docs.rs/egui-ash"
 repository = "https://github.com/MatchaChoco010/egui-ash"
 categories = ["gui"]
 keywords = ["gui", "egui", "ash", "vulkan", "winit"]
-include = [
-  "/LICENSE-*",
-  "/src/*.rs",
-  "/src/shaders/spv/*.spv",
-  "/Cargo.toml",
-]
+include = ["/LICENSE-*", "/src/*.rs", "/src/shaders/spv/*.spv", "/Cargo.toml"]
 
 [features]
 default = ["egui-winit/default"]
-gpu-allocator = [ "dep:gpu-allocator" ]
+gpu-allocator = ["dep:gpu-allocator"]
 persistence = [
-  "egui/persistence",
-  "egui-winit/serde",
-  "directories-next",
-  "dep:serde",
-  "ron",
+    "egui/persistence",
+    "egui-winit/serde",
+    "directories-next",
+    "dep:serde",
+    "ron",
 ]
 
 ## Underlying egui-winit features
@@ -43,24 +38,33 @@ x11 = ["egui-winit/x11"]
 
 [dependencies]
 anyhow = "1.0.75"
-ash = { version = "0.37.3", default-features = false }
-ash-window = "0.12.0"
+ash = { version = "0.38.0", default-features = false }
+ash-window = "0.13.0"
 bytemuck = "1.14.0"
 directories-next = { version = "2.0.0", optional = true }
-egui = "0.25.0"
-egui-winit = "0.25.0"
-gpu-allocator = { version = "0.25.0", default-features = false, features = ["vulkan"], optional = true }
+egui = "0.27.2"
+egui-winit = "0.27.2"
+gpu-allocator = { git = "https://github.com/Traverse-Research/gpu-allocator.git", default-features = false, features = [
+    "vulkan",
+], optional = true }
 log = "0.4.20"
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 ron = { version = "0.8.1", optional = true }
-serde = { version = "1.0.193", optional = true }
+serde = { version = "1.0.197", optional = true }
 
 [dev-dependencies]
-ash = { version = "0.37.3", default-features = false, features = ["linked", "debug"] }
-egui_extras = { version = "0.25.0", features = ["all_loaders"] }
+ash = { version = "0.38.0", default-features = false, features = [
+    "linked",
+    "debug",
+] }
+egui_extras = { version = "0.27.2", features = ["all_loaders"] }
 egui-ash = { path = ".", features = ["gpu-allocator", "persistence"] }
-egui_tiles = "0.6.0"
-glam = "0.25.0"
-image = { version = "0.24.7", default-features = false, features = ["png", "jpeg", "bmp"] }
+egui_tiles = "0.8.0"
+glam = "0.28.0"
+image = { version = "0.25.1", default-features = false, features = [
+    "png",
+    "jpeg",
+    "bmp",
+] }
 log = "0.4.20"
 tobj = "4.0.0"

--- a/examples/egui_ash_simple/main.rs
+++ b/examples/egui_ash_simple/main.rs
@@ -1,16 +1,14 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
 use egui::FontData;
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
     winit, App, AppCreator, AshRenderState, CreationContext, ExitSignal, RunOption, Theme,
 };
 use gpu_allocator::vulkan::*;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{
     collections::HashSet,
     ffi::CString,
@@ -23,9 +21,9 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Surface,
+    surface_loader: surface::Instance,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
@@ -164,8 +162,8 @@ impl MyAppCreator {
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -178,15 +176,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -199,7 +196,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -215,7 +212,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -229,12 +226,12 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+        surface::Instance::new(&entry, &instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+        swapchain::Device::new(&instance, &device)
     }
 
     fn create_surface(
@@ -246,8 +243,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Failed to get display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Failed to get window handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -256,7 +259,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -358,13 +361,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -372,7 +374,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -391,7 +393,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {

--- a/examples/egui_ash_vulkan/main.rs
+++ b/examples/egui_ash_vulkan/main.rs
@@ -1,15 +1,13 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
     winit, App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption, Theme,
 };
 use gpu_allocator::vulkan::*;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{
     collections::HashSet,
     ffi::CString,
@@ -24,11 +22,11 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Surface,
-    swapchain_loader: Swapchain,
+    surface_loader: surface::Instance,
+    swapchain_loader: swapchain::Device,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -168,8 +166,8 @@ impl MyAppCreator {
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -182,15 +180,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-winit-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -203,7 +200,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -219,7 +216,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -233,12 +230,12 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+        surface::Instance::new(&entry, &instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+        swapchain::Device::new(&instance, &device)
     }
 
     fn create_surface(
@@ -250,8 +247,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Failed to get display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Failed to get window handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -260,7 +263,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -362,13 +365,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -376,7 +378,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -395,7 +397,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {

--- a/examples/images/main.rs
+++ b/examples/images/main.rs
@@ -1,14 +1,12 @@
 use ash::vk::DebugUtilsMessengerEXT;
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
 use egui_ash::{winit, App, AppCreator, AshRenderState, CreationContext, RunOption};
 use gpu_allocator::vulkan::*;
-use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{
     collections::HashSet,
     ffi::CString,
@@ -20,11 +18,11 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Surface,
-    swapchain_loader: Swapchain,
+    surface_loader: surface::Instance,
+    swapchain_loader: swapchain::Device,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -97,8 +95,8 @@ impl MyAppCreator {
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (Instance, debug_utils::Instance, DebugUtilsMessengerEXT) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -111,15 +109,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -132,7 +129,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -148,7 +145,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -162,12 +159,12 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+        surface::Instance::new(&entry, &instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+        swapchain::Device::new(&instance, &device)
     }
 
     fn create_surface(
@@ -179,8 +176,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Failed to get display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Failed to get window handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -189,7 +192,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -291,13 +294,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -305,7 +307,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -324,7 +326,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {

--- a/examples/multi_viewports/main.rs
+++ b/examples/multi_viewports/main.rs
@@ -1,8 +1,6 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
 use egui_ash::{
@@ -25,11 +23,11 @@ struct MyApp {
     entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Arc<Surface>,
-    swapchain_loader: Arc<Swapchain>,
+    surface_loader: Arc<surface::Instance>,
+    swapchain_loader: Arc<swapchain::Device>,
 
     triangle_surface: vk::SurfaceKHR,
     model_surface: Option<vk::SurfaceKHR>,

--- a/examples/multi_viewports/model_renderer.rs
+++ b/examples/multi_viewports/model_renderer.rs
@@ -1,5 +1,5 @@
 use ash::{
-    extensions::khr::{Surface, Swapchain},
+    khr::{surface, swapchain},
     vk, Device,
 };
 use egui_ash::EguiCommand;
@@ -34,27 +34,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -73,8 +70,8 @@ struct ModelRendererInner {
 
     physical_device: vk::PhysicalDevice,
     device: Arc<Device>,
-    surface_loader: Arc<Surface>,
-    swapchain_loader: Arc<Swapchain>,
+    surface_loader: Arc<surface::Instance>,
+    swapchain_loader: Arc<swapchain::Device>,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
@@ -108,8 +105,8 @@ struct ModelRendererInner {
 impl ModelRendererInner {
     fn create_swapchain(
         physical_device: vk::PhysicalDevice,
-        surface_loader: &ash::extensions::khr::Surface,
-        swapchain_loader: &ash::extensions::khr::Swapchain,
+        surface_loader: &surface::Instance,
+        swapchain_loader: &swapchain::Device,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
         width: u32,
@@ -161,7 +158,7 @@ impl ModelRendererInner {
         let image_sharing_mode = vk::SharingMode::EXCLUSIVE;
         let queue_family_indices = [queue_family_index];
 
-        let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+        let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
             .surface(surface)
             .min_image_count(image_count)
             .image_format(surface_format.format)
@@ -198,7 +195,7 @@ impl ModelRendererInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -240,10 +237,10 @@ impl ModelRendererInner {
     }
 
     fn create_descriptor_pool(device: &Device, swapchain_count: usize) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(swapchain_count as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(swapchain_count as u32);
         unsafe {
@@ -257,12 +254,12 @@ impl ModelRendererInner {
         device: &Device,
         swapchain_count: usize,
     ) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..swapchain_count)
@@ -280,7 +277,7 @@ impl ModelRendererInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -289,11 +286,11 @@ impl ModelRendererInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -308,7 +305,7 @@ impl ModelRendererInner {
 
     fn create_render_pass(device: &Device, surface_format: vk::SurfaceFormatKHR) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(surface_format.format)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -316,9 +313,8 @@ impl ModelRendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -326,22 +322,19 @@ impl ModelRendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -374,18 +367,17 @@ impl ModelRendererInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(format.format)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -393,7 +385,7 @@ impl ModelRendererInner {
             };
             attachments.push(color_attachment);
             color_image_views.push(color_attachment);
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -434,18 +426,17 @@ impl ModelRendererInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -456,7 +447,7 @@ impl ModelRendererInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(extent.width)
@@ -483,7 +474,7 @@ impl ModelRendererInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -492,7 +483,7 @@ impl ModelRendererInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -501,33 +492,31 @@ impl ModelRendererInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -535,36 +524,36 @@ impl ModelRendererInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -641,7 +630,7 @@ impl ModelRendererInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -676,7 +665,7 @@ impl ModelRendererInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -710,7 +699,7 @@ impl ModelRendererInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -722,7 +711,7 @@ impl ModelRendererInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -730,11 +719,10 @@ impl ModelRendererInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -743,7 +731,7 @@ impl ModelRendererInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -774,7 +762,7 @@ impl ModelRendererInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(swapchain_count as u32),
@@ -788,7 +776,7 @@ impl ModelRendererInner {
         swapchain_count: usize,
     ) -> (Vec<vk::Fence>, Vec<vk::Semaphore>, Vec<vk::Semaphore>) {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..swapchain_count {
             let fence = unsafe {
@@ -800,7 +788,7 @@ impl ModelRendererInner {
         }
         let mut image_available_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -810,7 +798,7 @@ impl ModelRendererInner {
         }
         let mut render_finished_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -909,7 +897,7 @@ impl ModelRendererInner {
                 image_count
             };
 
-            let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+            let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
                 .surface(self.surface)
                 .min_image_count(image_count)
                 .image_color_space(surface_format.color_space)
@@ -977,8 +965,8 @@ impl ModelRendererInner {
     fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<surface::Instance>,
+        swapchain_loader: Arc<swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
@@ -1134,7 +1122,7 @@ impl ModelRendererInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1146,14 +1134,13 @@ impl ModelRendererInner {
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[index])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(vk::Offset2D::builder().x(0).y(0).build())
-                            .extent(self.surface_extent)
-                            .build(),
+                        vk::Rect2D::default()
+                            .offset(vk::Offset2D::default().x(0).y(0))
+                            .extent(self.surface_extent),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1179,7 +1166,7 @@ impl ModelRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(width as f32)
                         .height(height as f32)
                         .min_depth(0.0)
@@ -1190,8 +1177,8 @@ impl ModelRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(vk::Offset2D::builder().build())
+                    &vk::Rect2D::default()
+                        .offset(vk::Offset2D::default())
                         .extent(self.surface_extent),
                 ),
             );
@@ -1229,7 +1216,7 @@ impl ModelRendererInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder()
+        let submit_info = vk::SubmitInfo::default()
             .command_buffers(&buffers_to_submit)
             .wait_semaphores(std::slice::from_ref(
                 &self.image_available_semaphores[self.current_frame],
@@ -1249,7 +1236,7 @@ impl ModelRendererInner {
         };
 
         let image_indices = [index as u32];
-        let present_info = vk::PresentInfoKHR::builder()
+        let present_info = vk::PresentInfoKHR::default()
             .wait_semaphores(std::slice::from_ref(
                 &self.render_finished_semaphores[self.current_frame],
             ))
@@ -1337,8 +1324,8 @@ impl ModelRenderer {
     pub fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<surface::Instance>,
+        swapchain_loader: Arc<swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,

--- a/examples/multi_viewports/triangle_renderer.rs
+++ b/examples/multi_viewports/triangle_renderer.rs
@@ -1,5 +1,5 @@
 use ash::{
-    extensions::khr::{Surface, Swapchain},
+    khr::{surface, swapchain},
     vk, Device,
 };
 use egui_ash::EguiCommand;
@@ -35,27 +35,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -76,8 +73,8 @@ struct TriangleRendererInner {
 
     physical_device: vk::PhysicalDevice,
     device: Arc<Device>,
-    surface_loader: Arc<Surface>,
-    swapchain_loader: Arc<Swapchain>,
+    surface_loader: Arc<surface::Instance>,
+    swapchain_loader: Arc<swapchain::Device>,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
@@ -109,8 +106,8 @@ struct TriangleRendererInner {
 impl TriangleRendererInner {
     fn create_swapchain(
         physical_device: vk::PhysicalDevice,
-        surface_loader: &ash::extensions::khr::Surface,
-        swapchain_loader: &ash::extensions::khr::Swapchain,
+        surface_loader: &surface::Instance,
+        swapchain_loader: &swapchain::Device,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
         width: u32,
@@ -162,7 +159,7 @@ impl TriangleRendererInner {
         let image_sharing_mode = vk::SharingMode::EXCLUSIVE;
         let queue_family_indices = [queue_family_index];
 
-        let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+        let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
             .surface(surface)
             .min_image_count(image_count)
             .image_format(surface_format.format)
@@ -199,7 +196,7 @@ impl TriangleRendererInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -241,10 +238,10 @@ impl TriangleRendererInner {
     }
 
     fn create_descriptor_pool(device: &Device, swapchain_count: usize) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(swapchain_count as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(swapchain_count as u32);
         unsafe {
@@ -258,12 +255,12 @@ impl TriangleRendererInner {
         device: &Device,
         swapchain_count: usize,
     ) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..swapchain_count)
@@ -281,7 +278,7 @@ impl TriangleRendererInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -290,11 +287,11 @@ impl TriangleRendererInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -308,7 +305,7 @@ impl TriangleRendererInner {
     }
 
     fn create_render_pass(device: &Device, surface_format: vk::SurfaceFormatKHR) -> vk::RenderPass {
-        let attachments = [vk::AttachmentDescription::builder()
+        let attachments = [vk::AttachmentDescription::default()
             .format(surface_format.format)
             .samples(vk::SampleCountFlags::TYPE_1)
             .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -316,17 +313,14 @@ impl TriangleRendererInner {
             .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
             .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
             .initial_layout(vk::ImageLayout::UNDEFINED)
-            .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let color_reference = [vk::AttachmentReference::builder()
+            .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let subpasses = [vk::SubpassDescription::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
-            .color_attachments(&color_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .color_attachments(&color_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -351,18 +345,17 @@ impl TriangleRendererInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(format.format)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -373,7 +366,7 @@ impl TriangleRendererInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(extent.width)
@@ -394,7 +387,7 @@ impl TriangleRendererInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/triangle.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -403,7 +396,7 @@ impl TriangleRendererInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/triangle.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -412,33 +405,31 @@ impl TriangleRendererInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -446,36 +437,36 @@ impl TriangleRendererInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(false)
             .depth_write_enable(false)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -530,7 +521,7 @@ impl TriangleRendererInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -565,7 +556,7 @@ impl TriangleRendererInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -599,7 +590,7 @@ impl TriangleRendererInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -611,7 +602,7 @@ impl TriangleRendererInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -619,11 +610,10 @@ impl TriangleRendererInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -632,7 +622,7 @@ impl TriangleRendererInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -663,7 +653,7 @@ impl TriangleRendererInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(swapchain_count as u32),
@@ -677,7 +667,7 @@ impl TriangleRendererInner {
         swapchain_count: usize,
     ) -> (Vec<vk::Fence>, Vec<vk::Semaphore>, Vec<vk::Semaphore>) {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..swapchain_count {
             let fence = unsafe {
@@ -689,7 +679,7 @@ impl TriangleRendererInner {
         }
         let mut image_available_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -699,7 +689,7 @@ impl TriangleRendererInner {
         }
         let mut render_finished_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -790,7 +780,7 @@ impl TriangleRendererInner {
                 image_count
             };
 
-            let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+            let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
                 .surface(self.surface)
                 .min_image_count(image_count)
                 .image_color_space(surface_format.color_space)
@@ -854,8 +844,8 @@ impl TriangleRendererInner {
     fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<surface::Instance>,
+        swapchain_loader: Arc<swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
@@ -1013,7 +1003,7 @@ impl TriangleRendererInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1025,14 +1015,13 @@ impl TriangleRendererInner {
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[index])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(vk::Offset2D::builder().x(0).y(0).build())
-                            .extent(self.surface_extent)
-                            .build(),
+                        vk::Rect2D::default()
+                            .offset(vk::Offset2D::default().x(0).y(0))
+                            .extent(self.surface_extent),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1058,7 +1047,7 @@ impl TriangleRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(width as f32)
                         .height(height as f32)
                         .min_depth(0.0)
@@ -1069,8 +1058,8 @@ impl TriangleRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(vk::Offset2D::builder().build())
+                    &vk::Rect2D::default()
+                        .offset(vk::Offset2D::default())
                         .extent(self.surface_extent),
                 ),
             );
@@ -1108,7 +1097,7 @@ impl TriangleRendererInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder()
+        let submit_info = vk::SubmitInfo::default()
             .command_buffers(&buffers_to_submit)
             .wait_semaphores(std::slice::from_ref(
                 &self.image_available_semaphores[self.current_frame],
@@ -1128,7 +1117,7 @@ impl TriangleRendererInner {
         };
 
         let image_indices = [index as u32];
-        let present_info = vk::PresentInfoKHR::builder()
+        let present_info = vk::PresentInfoKHR::default()
             .wait_semaphores(std::slice::from_ref(
                 &self.render_finished_semaphores[self.current_frame],
             ))
@@ -1209,8 +1198,8 @@ impl TriangleRenderer {
     pub fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<surface::Instance>,
+        swapchain_loader: Arc<swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,

--- a/examples/multi_viewports/vkutils.rs
+++ b/examples/multi_viewports/vkutils.rs
@@ -1,14 +1,10 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
-use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
-    winit,
-};
+use egui_ash::winit;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{collections::HashSet, ffi::CString};
 
 const ENABLE_VALIDATION_LAYERS: bool = true;
@@ -46,8 +42,8 @@ pub fn create_entry() -> Entry {
 pub fn create_instance(
     required_instance_extensions: &[CString],
     entry: &Entry,
-) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -60,15 +56,14 @@ pub fn create_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
-        .pfn_user_callback(Some(vulkan_debug_utils_callback))
-        .build();
+        .pfn_user_callback(Some(vulkan_debug_utils_callback));
 
     let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(1, 0, 0, 0))
         .api_version(vk::API_VERSION_1_0);
-    let mut extension_names = vec![DebugUtils::name().as_ptr()];
+    let mut extension_names = vec![debug_utils::NAME.as_ptr()];
     for ext in required_instance_extensions {
         let name = ext.as_ptr();
         extension_names.push(name);
@@ -81,7 +76,7 @@ pub fn create_instance(
         .iter()
         .map(|l| l.as_ptr())
         .collect::<Vec<*const i8>>();
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
@@ -97,7 +92,7 @@ pub fn create_instance(
     };
 
     // setup debug utils
-    let debug_utils_loader = DebugUtils::new(&entry, &instance);
+    let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
     let debug_messenger = if ENABLE_VALIDATION_LAYERS {
         unsafe {
             debug_utils_loader
@@ -111,12 +106,12 @@ pub fn create_instance(
     (instance, debug_utils_loader, debug_messenger)
 }
 
-pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-    Surface::new(&entry, &instance)
+pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+    surface::Instance::new(&entry, &instance)
 }
 
-pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-    Swapchain::new(&instance, &device)
+pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+    swapchain::Device::new(&instance, &device)
 }
 
 pub fn create_surface(
@@ -128,8 +123,14 @@ pub fn create_surface(
         ash_window::create_surface(
             entry,
             instance,
-            window.raw_display_handle(),
-            window.raw_window_handle(),
+            window
+                .display_handle()
+                .expect("Failed to get display handle")
+                .as_raw(),
+            window
+                .window_handle()
+                .expect("Failed to get window handle")
+                .as_raw(),
             None,
         )
         .expect("Failed to create surface")
@@ -138,7 +139,7 @@ pub fn create_surface(
 
 pub fn create_physical_device(
     instance: &Instance,
-    surface_loader: &Surface,
+    surface_loader: &surface::Instance,
     surface: vk::SurfaceKHR,
     required_device_extensions: &[CString],
 ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -234,13 +235,12 @@ pub fn create_device(
 ) -> (Device, vk::Queue) {
     let queue_priorities = [1.0_f32];
     let mut queue_create_infos = vec![];
-    let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
         .queue_family_index(queue_family_index)
-        .queue_priorities(&queue_priorities)
-        .build();
+        .queue_priorities(&queue_priorities);
     queue_create_infos.push(queue_create_info);
 
-    let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+    let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
     let enable_extension_names = required_device_extensions
         .iter()
@@ -248,7 +248,7 @@ pub fn create_device(
         .collect::<Vec<_>>();
 
     // device create info
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_features(&physical_device_features)
         .enabled_extension_names(&enable_extension_names);
@@ -267,7 +267,7 @@ pub fn create_device(
 }
 
 pub fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-    let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+    let command_pool_create_info = vk::CommandPoolCreateInfo::default()
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .queue_family_index(queue_family_index);
     unsafe {

--- a/examples/scene_view/main.rs
+++ b/examples/scene_view/main.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::{ext::DebugUtils, khr::Surface},
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, khr::surface, vk, Device, Entry, Instance};
 use egui_ash::{App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption};
 use gpu_allocator::vulkan::*;
 use std::{
@@ -19,9 +16,9 @@ struct MyApp {
     _entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Arc<Surface>,
+    surface_loader: Arc<surface::Instance>,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,

--- a/examples/scene_view/scene_view.rs
+++ b/examples/scene_view/scene_view.rs
@@ -32,27 +32,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -114,7 +111,7 @@ impl SceneViewInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -156,10 +153,10 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(Self::IN_FLIGHT_FRAMES as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(Self::IN_FLIGHT_FRAMES as u32);
         unsafe {
@@ -170,12 +167,12 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_set_layouts(device: &Device) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..Self::IN_FLIGHT_FRAMES)
@@ -193,7 +190,7 @@ impl SceneViewInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -202,11 +199,11 @@ impl SceneViewInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -221,7 +218,7 @@ impl SceneViewInner {
 
     fn create_render_pass(device: &Device) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -229,9 +226,8 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -239,22 +235,19 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -292,7 +285,7 @@ impl SceneViewInner {
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let mut attachments = vec![];
 
-            let color_image_create_info = vk::ImageCreateInfo::builder()
+            let color_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -333,18 +326,17 @@ impl SceneViewInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(color_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::R8G8B8A8_UNORM)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -355,7 +347,7 @@ impl SceneViewInner {
             color_image_allocations.push(color_allocation);
             color_image_views.push(color_attachment);
 
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -396,18 +388,17 @@ impl SceneViewInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -421,7 +412,7 @@ impl SceneViewInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(width)
@@ -435,7 +426,7 @@ impl SceneViewInner {
             let cmd = unsafe {
                 device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_pool(command_pool)
                             .level(vk::CommandBufferLevel::PRIMARY)
                             .command_buffer_count(1),
@@ -446,7 +437,7 @@ impl SceneViewInner {
                 device
                     .begin_command_buffer(
                         cmd,
-                        &vk::CommandBufferBeginInfo::builder()
+                        &vk::CommandBufferBeginInfo::default()
                             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                     )
                     .expect("Failed to begin command buffer");
@@ -463,13 +454,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
             unsafe {
                 device
@@ -478,7 +468,7 @@ impl SceneViewInner {
                 device
                     .queue_submit(
                         queue,
-                        &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                        &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                         vk::Fence::null(),
                     )
                     .expect("Failed to submit queue");
@@ -500,7 +490,7 @@ impl SceneViewInner {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -522,7 +512,7 @@ impl SceneViewInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -531,7 +521,7 @@ impl SceneViewInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -540,33 +530,31 @@ impl SceneViewInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -574,36 +562,36 @@ impl SceneViewInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -680,7 +668,7 @@ impl SceneViewInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -715,7 +703,7 @@ impl SceneViewInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -749,7 +737,7 @@ impl SceneViewInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -761,7 +749,7 @@ impl SceneViewInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -769,11 +757,10 @@ impl SceneViewInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -782,7 +769,7 @@ impl SceneViewInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -812,7 +799,7 @@ impl SceneViewInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(Self::IN_FLIGHT_FRAMES as u32),
@@ -823,7 +810,7 @@ impl SceneViewInner {
 
     fn create_sync_objects(device: &Device) -> Vec<vk::Fence> {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let fence = unsafe {
@@ -1055,7 +1042,7 @@ impl SceneViewInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1077,29 +1064,27 @@ impl SceneViewInner {
                 vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[self.current_frame])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(*vk::Offset2D::builder().x(0).y(0))
+                        vk::Rect2D::default()
+                            .offset(vk::Offset2D::default().x(0).y(0))
                             .extent(
-                                *vk::Extent2D::builder()
+                                vk::Extent2D::default()
                                     .width(self.width)
                                     .height(self.height),
-                            )
-                            .build(),
+                            ),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1125,7 +1110,7 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(self.width as f32)
                         .height(self.height as f32)
                         .min_depth(0.0)
@@ -1136,10 +1121,10 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(*vk::Offset2D::builder())
+                    &vk::Rect2D::default()
+                        .offset(vk::Offset2D::default())
                         .extent(
-                            *vk::Extent2D::builder()
+                            vk::Extent2D::default()
                                 .width(self.width)
                                 .height(self.height),
                         ),
@@ -1183,13 +1168,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device
@@ -1198,7 +1182,7 @@ impl SceneViewInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&buffers_to_submit);
+        let submit_info = vk::SubmitInfo::default().command_buffers(&buffers_to_submit);
         unsafe {
             self.device
                 .queue_submit(

--- a/examples/scene_view/vkutils.rs
+++ b/examples/scene_view/vkutils.rs
@@ -1,14 +1,10 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
-use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
-    winit,
-};
+use egui_ash::winit;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{collections::HashSet, ffi::CString};
 
 const ENABLE_VALIDATION_LAYERS: bool = true;
@@ -46,8 +42,8 @@ pub fn create_entry() -> Entry {
 pub fn create_instance(
     required_instance_extensions: &[CString],
     entry: &Entry,
-) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -60,15 +56,14 @@ pub fn create_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
-        .pfn_user_callback(Some(vulkan_debug_utils_callback))
-        .build();
+        .pfn_user_callback(Some(vulkan_debug_utils_callback));
 
     let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(1, 0, 0, 0))
         .api_version(vk::API_VERSION_1_0);
-    let mut extension_names = vec![DebugUtils::name().as_ptr()];
+    let mut extension_names = vec![debug_utils::NAME.as_ptr()];
     for ext in required_instance_extensions {
         let name = ext.as_ptr();
         extension_names.push(name);
@@ -81,7 +76,7 @@ pub fn create_instance(
         .iter()
         .map(|l| l.as_ptr())
         .collect::<Vec<*const i8>>();
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
@@ -97,7 +92,7 @@ pub fn create_instance(
     };
 
     // setup debug utils
-    let debug_utils_loader = DebugUtils::new(&entry, &instance);
+    let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
     let debug_messenger = if ENABLE_VALIDATION_LAYERS {
         unsafe {
             debug_utils_loader
@@ -111,12 +106,12 @@ pub fn create_instance(
     (instance, debug_utils_loader, debug_messenger)
 }
 
-pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-    Surface::new(&entry, &instance)
+pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+    surface::Instance::new(&entry, &instance)
 }
 
-pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-    Swapchain::new(&instance, &device)
+pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+    swapchain::Device::new(&instance, &device)
 }
 
 pub fn create_surface(
@@ -128,8 +123,14 @@ pub fn create_surface(
         ash_window::create_surface(
             entry,
             instance,
-            window.raw_display_handle(),
-            window.raw_window_handle(),
+            window
+                .display_handle()
+                .expect("Failed to get display handle")
+                .as_raw(),
+            window
+                .window_handle()
+                .expect("Failed to get window handle")
+                .as_raw(),
             None,
         )
         .expect("Failed to create surface")
@@ -138,7 +139,7 @@ pub fn create_surface(
 
 pub fn create_physical_device(
     instance: &Instance,
-    surface_loader: &Surface,
+    surface_loader: &surface::Instance,
     surface: vk::SurfaceKHR,
     required_device_extensions: &[CString],
 ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -234,13 +235,12 @@ pub fn create_device(
 ) -> (Device, vk::Queue) {
     let queue_priorities = [1.0_f32];
     let mut queue_create_infos = vec![];
-    let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
         .queue_family_index(queue_family_index)
-        .queue_priorities(&queue_priorities)
-        .build();
+        .queue_priorities(&queue_priorities);
     queue_create_infos.push(queue_create_info);
 
-    let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+    let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
     let enable_extension_names = required_device_extensions
         .iter()
@@ -248,7 +248,7 @@ pub fn create_device(
         .collect::<Vec<_>>();
 
     // device create info
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_features(&physical_device_features)
         .enabled_extension_names(&enable_extension_names);
@@ -267,7 +267,7 @@ pub fn create_device(
 }
 
 pub fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-    let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+    let command_pool_create_info = vk::CommandPoolCreateInfo::default()
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .queue_family_index(queue_family_index);
     unsafe {
@@ -291,7 +291,7 @@ pub fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
@@ -299,8 +299,7 @@ pub fn insert_image_memory_barrier(
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
         .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
             *cmd,

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::{ext::DebugUtils, khr::Surface},
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, khr::surface, vk, Device, Entry, Instance};
 use egui_ash::{App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption};
 use gpu_allocator::vulkan::*;
 use std::{
@@ -25,9 +22,9 @@ struct MyApp {
     _entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Arc<Surface>,
+    surface_loader: Arc<surface::Instance>,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,

--- a/examples/tiles/scene_view.rs
+++ b/examples/tiles/scene_view.rs
@@ -32,27 +32,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -121,7 +118,7 @@ impl SceneViewInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -163,10 +160,10 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(Self::IN_FLIGHT_FRAMES as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(Self::IN_FLIGHT_FRAMES as u32);
         unsafe {
@@ -177,12 +174,12 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_set_layouts(device: &Device) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..Self::IN_FLIGHT_FRAMES)
@@ -200,7 +197,7 @@ impl SceneViewInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -209,11 +206,11 @@ impl SceneViewInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -228,7 +225,7 @@ impl SceneViewInner {
 
     fn create_render_pass(device: &Device) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -236,9 +233,8 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -246,22 +242,19 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -299,7 +292,7 @@ impl SceneViewInner {
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let mut attachments = vec![];
 
-            let color_image_create_info = vk::ImageCreateInfo::builder()
+            let color_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -340,18 +333,17 @@ impl SceneViewInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(color_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::R8G8B8A8_UNORM)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -362,7 +354,7 @@ impl SceneViewInner {
             color_image_allocations.push(color_allocation);
             color_image_views.push(color_attachment);
 
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -403,18 +395,17 @@ impl SceneViewInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -428,7 +419,7 @@ impl SceneViewInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(width)
@@ -442,7 +433,7 @@ impl SceneViewInner {
             let cmd = unsafe {
                 device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_pool(command_pool)
                             .level(vk::CommandBufferLevel::PRIMARY)
                             .command_buffer_count(1),
@@ -453,7 +444,7 @@ impl SceneViewInner {
                 device
                     .begin_command_buffer(
                         cmd,
-                        &vk::CommandBufferBeginInfo::builder()
+                        &vk::CommandBufferBeginInfo::default()
                             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                     )
                     .expect("Failed to begin command buffer");
@@ -470,13 +461,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
             unsafe {
                 device
@@ -485,7 +475,7 @@ impl SceneViewInner {
                 device
                     .queue_submit(
                         queue,
-                        &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                        &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                         vk::Fence::null(),
                     )
                     .expect("Failed to submit queue");
@@ -507,7 +497,7 @@ impl SceneViewInner {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -529,7 +519,7 @@ impl SceneViewInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -538,7 +528,7 @@ impl SceneViewInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -547,33 +537,31 @@ impl SceneViewInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -581,36 +569,36 @@ impl SceneViewInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -687,7 +675,7 @@ impl SceneViewInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -722,7 +710,7 @@ impl SceneViewInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -756,7 +744,7 @@ impl SceneViewInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -768,7 +756,7 @@ impl SceneViewInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -776,11 +764,10 @@ impl SceneViewInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -789,7 +776,7 @@ impl SceneViewInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -819,7 +806,7 @@ impl SceneViewInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(Self::IN_FLIGHT_FRAMES as u32),
@@ -830,7 +817,7 @@ impl SceneViewInner {
 
     fn create_sync_objects(device: &Device) -> Vec<vk::Fence> {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let fence = unsafe {
@@ -1076,7 +1063,7 @@ impl SceneViewInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1098,29 +1085,27 @@ impl SceneViewInner {
                 vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[self.current_frame])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(*vk::Offset2D::builder().x(0).y(0))
+                        vk::Rect2D::default()
+                            .offset(vk::Offset2D::default().x(0).y(0))
                             .extent(
-                                *vk::Extent2D::builder()
+                                vk::Extent2D::default()
                                     .width(self.width)
                                     .height(self.height),
-                            )
-                            .build(),
+                            ),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1151,7 +1136,7 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(self.width as f32)
                         .height(self.height as f32)
                         .min_depth(0.0)
@@ -1162,10 +1147,10 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(*vk::Offset2D::builder())
+                    &vk::Rect2D::default()
+                        .offset(vk::Offset2D::default())
                         .extent(
-                            *vk::Extent2D::builder()
+                            vk::Extent2D::default()
                                 .width(self.width)
                                 .height(self.height),
                         ),
@@ -1209,13 +1194,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device
@@ -1224,7 +1208,7 @@ impl SceneViewInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&buffers_to_submit);
+        let submit_info = vk::SubmitInfo::default().command_buffers(&buffers_to_submit);
         unsafe {
             self.device
                 .queue_submit(

--- a/examples/tiles/vkutils.rs
+++ b/examples/tiles/vkutils.rs
@@ -1,14 +1,10 @@
 use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
+    ext::debug_utils,
+    khr::{surface, swapchain},
     vk, Device, Entry, Instance,
 };
-use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
-    winit,
-};
+use egui_ash::winit;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{collections::HashSet, ffi::CString};
 
 const ENABLE_VALIDATION_LAYERS: bool = true;
@@ -46,8 +42,8 @@ pub fn create_entry() -> Entry {
 pub fn create_instance(
     required_instance_extensions: &[CString],
     entry: &Entry,
-) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -60,15 +56,14 @@ pub fn create_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
-        .pfn_user_callback(Some(vulkan_debug_utils_callback))
-        .build();
+        .pfn_user_callback(Some(vulkan_debug_utils_callback));
 
     let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(1, 0, 0, 0))
         .api_version(vk::API_VERSION_1_0);
-    let mut extension_names = vec![DebugUtils::name().as_ptr()];
+    let mut extension_names = vec![debug_utils::NAME.as_ptr()];
     for ext in required_instance_extensions {
         let name = ext.as_ptr();
         extension_names.push(name);
@@ -81,7 +76,7 @@ pub fn create_instance(
         .iter()
         .map(|l| l.as_ptr())
         .collect::<Vec<*const i8>>();
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
@@ -97,7 +92,7 @@ pub fn create_instance(
     };
 
     // setup debug utils
-    let debug_utils_loader = DebugUtils::new(&entry, &instance);
+    let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
     let debug_messenger = if ENABLE_VALIDATION_LAYERS {
         unsafe {
             debug_utils_loader
@@ -111,12 +106,12 @@ pub fn create_instance(
     (instance, debug_utils_loader, debug_messenger)
 }
 
-pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-    Surface::new(&entry, &instance)
+pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> surface::Instance {
+    surface::Instance::new(&entry, &instance)
 }
 
-pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-    Swapchain::new(&instance, &device)
+pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> swapchain::Device {
+    swapchain::Device::new(&instance, &device)
 }
 
 pub fn create_surface(
@@ -128,8 +123,14 @@ pub fn create_surface(
         ash_window::create_surface(
             entry,
             instance,
-            window.raw_display_handle(),
-            window.raw_window_handle(),
+            window
+                .display_handle()
+                .expect("Failed to get display handle")
+                .as_raw(),
+            window
+                .window_handle()
+                .expect("Failed to get window handle")
+                .as_raw(),
             None,
         )
         .expect("Failed to create surface")
@@ -138,7 +139,7 @@ pub fn create_surface(
 
 pub fn create_physical_device(
     instance: &Instance,
-    surface_loader: &Surface,
+    surface_loader: &surface::Instance,
     surface: vk::SurfaceKHR,
     required_device_extensions: &[CString],
 ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -234,13 +235,12 @@ pub fn create_device(
 ) -> (Device, vk::Queue) {
     let queue_priorities = [1.0_f32];
     let mut queue_create_infos = vec![];
-    let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
         .queue_family_index(queue_family_index)
-        .queue_priorities(&queue_priorities)
-        .build();
+        .queue_priorities(&queue_priorities);
     queue_create_infos.push(queue_create_info);
 
-    let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+    let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
     let enable_extension_names = required_device_extensions
         .iter()
@@ -248,7 +248,7 @@ pub fn create_device(
         .collect::<Vec<_>>();
 
     // device create info
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_features(&physical_device_features)
         .enabled_extension_names(&enable_extension_names);
@@ -267,7 +267,7 @@ pub fn create_device(
 }
 
 pub fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-    let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+    let command_pool_create_info = vk::CommandPoolCreateInfo::default()
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .queue_family_index(queue_family_index);
     unsafe {
@@ -291,7 +291,7 @@ pub fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
@@ -299,8 +299,7 @@ pub fn insert_image_memory_barrier(
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
         .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
             *cmd,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use ash::{
-    extensions::khr::{Surface, Swapchain},
-    vk, Device, Entry, Instance,
+    khr::surface::Instance as Surface, khr::swapchain::Device as Swapchain, vk, Device, Entry,
+    Instance,
 };
 use egui_winit::winit;
 use std::ffi::CString;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -53,9 +53,9 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     fn create_render_pass(device: &Device, surface_format: vk::Format) -> vk::RenderPass {
         unsafe {
             device.create_render_pass(
-                &vk::RenderPassCreateInfo::builder()
+                &vk::RenderPassCreateInfo::default()
                     .attachments(std::slice::from_ref(
-                        &vk::AttachmentDescription::builder()
+                        &vk::AttachmentDescription::default()
                             .format(surface_format)
                             .samples(vk::SampleCountFlags::TYPE_1)
                             .load_op(vk::AttachmentLoadOp::LOAD)
@@ -66,16 +66,16 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                             .final_layout(vk::ImageLayout::PRESENT_SRC_KHR),
                     ))
                     .subpasses(std::slice::from_ref(
-                        &vk::SubpassDescription::builder()
+                        &vk::SubpassDescription::default()
                             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
                             .color_attachments(std::slice::from_ref(
-                                &vk::AttachmentReference::builder()
+                                &vk::AttachmentReference::default()
                                     .attachment(0)
                                     .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
                             )),
                     ))
                     .dependencies(std::slice::from_ref(
-                        &vk::SubpassDependency::builder()
+                        &vk::SubpassDependency::default()
                             .src_subpass(vk::SUBPASS_EXTERNAL)
                             .dst_subpass(0)
                             .src_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
@@ -95,10 +95,10 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     ) -> vk::PipelineLayout {
         unsafe {
             device.create_pipeline_layout(
-                &vk::PipelineLayoutCreateInfo::builder()
+                &vk::PipelineLayoutCreateInfo::default()
                     .set_layouts(&[descriptor_set_layout])
                     .push_constant_ranges(std::slice::from_ref(
-                        &vk::PushConstantRange::builder()
+                        &vk::PushConstantRange::default()
                             .stage_flags(vk::ShaderStageFlags::VERTEX)
                             .offset(0)
                             .size(std::mem::size_of::<f32>() as u32 * 2),
@@ -116,26 +116,23 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     ) -> vk::Pipeline {
         let attributes = [
             // position
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(0)
                 .location(0)
-                .format(vk::Format::R32G32_SFLOAT)
-                .build(),
+                .format(vk::Format::R32G32_SFLOAT),
             // uv
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(8)
                 .location(1)
-                .format(vk::Format::R32G32_SFLOAT)
-                .build(),
+                .format(vk::Format::R32G32_SFLOAT),
             // color
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(16)
                 .location(2)
-                .format(vk::Format::R8G8B8A8_UNORM)
-                .build(),
+                .format(vk::Format::R8G8B8A8_UNORM),
         ];
 
         let vertex_shader_module = {
@@ -160,24 +157,22 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
 
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -185,7 +180,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(false)
             .depth_write_enable(false)
             .depth_compare_op(vk::CompareOp::ALWAYS)
@@ -205,21 +200,21 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             });
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
 
         let pipeline = unsafe {
             device.create_graphics_pipelines(
                 vk::PipelineCache::null(),
                 std::slice::from_ref(
-                    &vk::GraphicsPipelineCreateInfo::builder()
+                    &vk::GraphicsPipelineCreateInfo::default()
                         .stages(&pipeline_shader_stages)
                         .vertex_input_state(
-                            &vk::PipelineVertexInputStateCreateInfo::builder()
+                            &vk::PipelineVertexInputStateCreateInfo::default()
                                 .vertex_attribute_descriptions(&attributes)
                                 .vertex_binding_descriptions(std::slice::from_ref(
-                                    &vk::VertexInputBindingDescription::builder()
+                                    &vk::VertexInputBindingDescription::default()
                                         .binding(0)
                                         .input_rate(vk::VertexInputRate::VERTEX)
                                         .stride(
@@ -234,9 +229,9 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                         .multisample_state(&multisample_info)
                         .depth_stencil_state(&depth_stencil_info)
                         .color_blend_state(
-                            &vk::PipelineColorBlendStateCreateInfo::builder().attachments(
+                            &vk::PipelineColorBlendStateCreateInfo::default().attachments(
                                 std::slice::from_ref(
-                                    &vk::PipelineColorBlendAttachmentState::builder()
+                                    &vk::PipelineColorBlendAttachmentState::default()
                                         .color_write_mask(
                                             vk::ColorComponentFlags::R
                                                 | vk::ColorComponentFlags::G
@@ -280,12 +275,12 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             .map(|swapchain_image| unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(swapchain_image.clone())
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(surface_format)
                             .subresource_range(
-                                *vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
@@ -303,7 +298,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                 let attachments = &[image_views];
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments)
                             .width(width)
@@ -336,7 +331,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             let vertex_buffer = unsafe {
                 device
                     .create_buffer(
-                        &vk::BufferCreateInfo::builder()
+                        &vk::BufferCreateInfo::default()
                             .usage(vk::BufferUsageFlags::VERTEX_BUFFER)
                             .sharing_mode(vk::SharingMode::EXCLUSIVE)
                             .size(Self::vertex_buffer_size()),
@@ -367,7 +362,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             let index_buffer = unsafe {
                 device
                     .create_buffer(
-                        &vk::BufferCreateInfo::builder()
+                        &vk::BufferCreateInfo::default()
                             .usage(vk::BufferUsageFlags::INDEX_BUFFER)
                             .sharing_mode(vk::SharingMode::EXCLUSIVE)
                             .size(Self::index_buffer_size()),
@@ -581,13 +576,13 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                     unsafe {
                         this.device.cmd_begin_render_pass(
                             cmd,
-                            &vk::RenderPassBeginInfo::builder()
+                            &vk::RenderPassBeginInfo::default()
                                 .render_pass(state.render_pass)
                                 .framebuffer(state.framebuffers[index])
                                 .clear_values(&[])
                                 .render_area(
-                                    *vk::Rect2D::builder().extent(
-                                        *vk::Extent2D::builder()
+                                    vk::Rect2D::default().extent(
+                                        vk::Extent2D::default()
                                             .width(state.width)
                                             .height(state.height),
                                     ),
@@ -738,7 +733,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                                 cmd,
                                 0,
                                 std::slice::from_ref(
-                                    &vk::Rect2D::builder()
+                                    &vk::Rect2D::default()
                                         .offset(vk::Offset2D {
                                             x: min.x.round() as i32,
                                             y: min.y.round() as i32,
@@ -753,7 +748,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                                 cmd,
                                 0,
                                 std::slice::from_ref(
-                                    &vk::Viewport::builder()
+                                    &vk::Viewport::default()
                                         .x(0.0)
                                         .y(0.0)
                                         .width(state.physical_width as f32)
@@ -849,7 +844,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -914,7 +909,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .create_command_pool(
-                        &vk::CommandPoolCreateInfo::builder()
+                        &vk::CommandPoolCreateInfo::default()
                             .queue_family_index(self.queue_family_index),
                         None,
                     )
@@ -925,7 +920,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_buffer_count(1u32)
                             .command_pool(cmd_pool)
                             .level(vk::CommandBufferLevel::PRIMARY),
@@ -935,13 +930,13 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
         };
         let cmd_fence = unsafe {
             self.device
-                .create_fence(&vk::FenceCreateInfo::builder(), None)
+                .create_fence(&vk::FenceCreateInfo::default(), None)
                 .unwrap()
         };
 
         let (staging_buffer, staging_allocation) = {
             let buffer_size = data.len() as vk::DeviceSize;
-            let buffer_info = vk::BufferCreateInfo::builder()
+            let buffer_info = vk::BufferCreateInfo::default()
                 .size(buffer_size)
                 .usage(vk::BufferUsageFlags::TRANSFER_SRC);
             let texture_buffer = unsafe { self.device.create_buffer(&buffer_info, None) }.unwrap();
@@ -975,7 +970,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             };
             let handle = unsafe {
                 self.device.create_image(
-                    &vk::ImageCreateInfo::builder()
+                    &vk::ImageCreateInfo::default()
                         .array_layers(1)
                         .extent(extent)
                         .flags(vk::ImageCreateFlags::empty())
@@ -1016,7 +1011,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .components(vk::ComponentMapping::default())
                             .flags(vk::ImageViewCreateFlags::empty())
                             .format(vk::Format::R8G8B8A8_UNORM)
@@ -1040,7 +1035,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             self.device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .unwrap();
@@ -1073,7 +1068,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                 texture_image,
                 vk::ImageLayout::TRANSFER_DST_OPTIMAL,
                 std::slice::from_ref(
-                    &vk::BufferImageCopy::builder()
+                    &vk::BufferImageCopy::default()
                         .buffer_offset(0)
                         .buffer_row_length(delta.image.width() as u32)
                         .buffer_image_height(delta.image.height() as u32)
@@ -1121,7 +1116,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             self.device
                 .queue_submit(
                     self.queue,
-                    std::slice::from_ref(&vk::SubmitInfo::builder().command_buffers(&cmd_buffs)),
+                    std::slice::from_ref(&vk::SubmitInfo::default().command_buffers(&cmd_buffs)),
                     cmd_fence,
                 )
                 .unwrap();
@@ -1151,7 +1146,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                     self.device
                         .begin_command_buffer(
                             cmd,
-                            &vk::CommandBufferBeginInfo::builder()
+                            &vk::CommandBufferBeginInfo::default()
                                 .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                         )
                         .unwrap();
@@ -1269,7 +1264,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                         .queue_submit(
                             self.queue,
                             std::slice::from_ref(
-                                &vk::SubmitInfo::builder().command_buffers(&cmd_buffs),
+                                &vk::SubmitInfo::default().command_buffers(&cmd_buffs),
                             ),
                             cmd_fence,
                         )
@@ -1294,7 +1289,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                 unsafe {
                     self.device
                         .allocate_descriptor_sets(
-                            &vk::DescriptorSetAllocateInfo::builder()
+                            &vk::DescriptorSetAllocateInfo::default()
                                 .descriptor_pool(self.descriptor_pool)
                                 .set_layouts(&[self.descriptor_set_layout]),
                         )
@@ -1304,13 +1299,13 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device.update_descriptor_sets(
                     std::slice::from_ref(
-                        &vk::WriteDescriptorSet::builder()
+                        &vk::WriteDescriptorSet::default()
                             .dst_set(dsc_set)
                             .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                             .dst_array_element(0_u32)
                             .dst_binding(0_u32)
                             .image_info(std::slice::from_ref(
-                                &vk::DescriptorImageInfo::builder()
+                                &vk::DescriptorImageInfo::default()
                                     .image_view(texture_image_view)
                                     .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                                     .sampler(self.sampler),
@@ -1487,7 +1482,7 @@ impl UserTextures {
                     id,
                     self.device
                         .allocate_descriptor_sets(
-                            &vk::DescriptorSetAllocateInfo::builder()
+                            &vk::DescriptorSetAllocateInfo::default()
                                 .descriptor_pool(self.descriptor_pool)
                                 .set_layouts(&[self.descriptor_set_layout]),
                         )
@@ -1499,13 +1494,13 @@ impl UserTextures {
         unsafe {
             self.device.update_descriptor_sets(
                 std::slice::from_ref(
-                    &vk::WriteDescriptorSet::builder()
+                    &vk::WriteDescriptorSet::default()
                         .dst_set(*dsc_set)
                         .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                         .dst_array_element(0_u32)
                         .dst_binding(0_u32)
                         .image_info(std::slice::from_ref(
-                            &vk::DescriptorImageInfo::builder()
+                            &vk::DescriptorImageInfo::default()
                                 .image_view(image_view)
                                 .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                                 .sampler(sampler),
@@ -1571,11 +1566,11 @@ impl<A: Allocator + 'static> Renderer<A> {
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
         unsafe {
             device.create_descriptor_pool(
-                &vk::DescriptorPoolCreateInfo::builder()
+                &vk::DescriptorPoolCreateInfo::default()
                     .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
                     .max_sets(1024)
                     .pool_sizes(std::slice::from_ref(
-                        &vk::DescriptorPoolSize::builder()
+                        &vk::DescriptorPoolSize::default()
                             .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                             .descriptor_count(1024),
                     )),
@@ -1588,8 +1583,8 @@ impl<A: Allocator + 'static> Renderer<A> {
     fn create_descriptor_set_layout(device: &Device) -> vk::DescriptorSetLayout {
         unsafe {
             device.create_descriptor_set_layout(
-                &vk::DescriptorSetLayoutCreateInfo::builder().bindings(std::slice::from_ref(
-                    &vk::DescriptorSetLayoutBinding::builder()
+                &vk::DescriptorSetLayoutCreateInfo::default().bindings(std::slice::from_ref(
+                    &vk::DescriptorSetLayoutBinding::default()
                         .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                         .descriptor_count(1)
                         .binding(0)

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,5 @@
-use ash::extensions::khr::Swapchain;
 use egui_winit::winit::{self, event_loop::EventLoopBuilder};
-use raw_window_handle::HasRawDisplayHandle;
+use raw_window_handle::HasDisplayHandle;
 use std::{
     ffi::CStr,
     mem::ManuallyDrop,
@@ -77,7 +76,7 @@ pub fn run<C: AppCreator<A> + 'static, A: Allocator + 'static>(
 ) -> ExitCode {
     let app_id = app_id.into();
 
-    let device_extensions = [Swapchain::name().to_owned()];
+    let device_extensions = [ash::khr::swapchain::NAME.to_owned()];
 
     let event_loop = EventLoopBuilder::<IntegrationEvent>::with_user_event()
         .build()
@@ -142,8 +141,13 @@ pub fn run<C: AppCreator<A> + 'static, A: Allocator + 'static>(
             .unwrap()
     };
 
-    let instance_extensions =
-        ash_window::enumerate_required_extensions(event_loop.raw_display_handle()).unwrap();
+    let instance_extensions = ash_window::enumerate_required_extensions(
+        event_loop
+            .display_handle()
+            .expect("Error getting display handle")
+            .as_raw(),
+    )
+    .unwrap();
     let instance_extensions = instance_extensions
         .into_iter()
         .map(|&ext| unsafe { CStr::from_ptr(ext).to_owned() })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ pub(crate) fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
@@ -23,8 +23,7 @@ pub(crate) fn insert_image_memory_barrier(
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
         .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
             *cmd,


### PR DESCRIPTION
Hey all,

First of all, thanks for this project! I have been using it to get my bearings with GUI programming in Rust and love it so far.

This PR is my attempt to update this project and its examples to the latest ash and egui crates. ash 0.38 introduced a large number of breaking changes by separating Instance and Device level functions for extension structs, moving around a number of exports, and getting rid of builder patterns in favor of default implementations. As such, this PR is almost entirely refactoring and very little logic changes. I'll be honest, I'm a bit in over my depth here as I'm not an expert in this crate, egui, ash, or even vulkan, but I figured at least this should serve as a decent starting point for a proper update. In my testing at least, all of the examples appear to work.

I'm marking this as a WIP because it depends on some currently unreleased changes in the `gpu_allocator` crate to support the same ash changes, so until that gets a proper versioned release this will not be able to be released on crates.io.

Looks like my formatter went to town on a couple of things as well, if that's an issue let me know and I can try to clean it up!