### PR TITLE
Upgrade crates and fix standard+synchronization validation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
+checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -20,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8410747ed85a17c4a1e9ed3f5a74d3e7bdcc876cf9a18ff40ae21d645997b2"
+checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
 dependencies = [
  "enumn",
  "serde",
@@ -51,13 +51,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8c9b4467d77cacfbc93cee9aa8e7822f6d527c774efdca5f8b3a5280c34847"
+checksum = "09f46c18d99ba61ad7123dd13eeb0c104436ab6af1df6a1cd8c11054ed394a08"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "async-channel 1.9.0",
+ "async-channel",
  "async-once-cell",
  "atspi",
  "futures-lite 1.13.0",
@@ -101,9 +101,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -115,21 +115,21 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android-activity"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b801912a977c3fd52d80511fe1c0c8480c6f957f21ae2ce1b92ffe970cf4b9"
+checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
 dependencies = [
  "android-properties",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cc",
  "cesu8",
  "jni",
@@ -151,32 +151,30 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arboard"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
+checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
 dependencies = [
  "clipboard-win",
  "log",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "parking_lot",
- "thiserror",
- "winapi",
- "x11rb 0.12.0",
+ "x11rb",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -192,18 +190,18 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 
 [[package]]
 name = "ash-window"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b912285a7c29f3a8f87ca6f55afc48768624e5e33ec17dbd2f2075903f5e35ab"
+checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
 dependencies = [
  "ash",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "raw-window-metal",
 ]
 
@@ -219,23 +217,11 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
-dependencies = [
- "concurrent-queue",
- "event-listener 4.0.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -243,15 +229,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.8.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
- "async-lock 3.2.0",
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.1",
- "futures-lite 2.1.0",
+ "fastrand 2.1.0",
+ "futures-lite 2.3.0",
  "slab",
 ]
 
@@ -289,18 +274,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.3.0",
  "parking",
- "polling 3.3.1",
- "rustix 0.38.26",
+ "polling 3.7.2",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -317,11 +302,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -345,54 +330,54 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.26",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
 dependencies = [
- "async-io 2.2.1",
- "async-lock 2.8.0",
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.26",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.5.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -451,15 +436,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -469,9 +460,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -506,7 +497,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
 dependencies = [
- "objc-sys 0.3.2",
+ "objc-sys 0.3.5",
 ]
 
 [[package]]
@@ -530,45 +521,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.5.1"
+name = "block2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "async-channel 2.1.1",
- "async-lock 3.2.0",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
  "async-task",
- "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.3.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -579,20 +576,34 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "calloop"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50b5a44d59a98c55a9eeb518f39bf7499ba19fd98ee7d22618687f3f10adbf"
+checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "log",
- "polling 3.3.1",
- "rustix 0.38.26",
+ "polling 3.7.2",
+ "rustix 0.38.34",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+ "polling 3.7.2",
+ "rustix 0.38.34",
  "slab",
  "thiserror",
 ]
@@ -603,17 +614,29 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
 dependencies = [
- "calloop",
- "rustix 0.38.26",
+ "calloop 0.12.4",
+ "rustix 0.38.34",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.34",
  "wayland-backend",
  "wayland-client",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
@@ -639,13 +662,11 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -686,9 +707,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
-version = "4.6.6"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -696,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -721,9 +742,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -745,30 +766,27 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -851,37 +869,39 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e493c573fce17f00dcab13b6ac057994f3ce17d1af4dc39bfd482b83c6eb6157"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
 ]
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "ecolor"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57539aabcdbb733b6806ef421b66dec158dc1582107ad6d51913db3600303354"
+checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
 dependencies = [
  "bytemuck",
+ "emath",
  "serde",
 ]
 
 [[package]]
 name = "egui"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf640ed7f3bf3d14ebf00d73bacc09c886443ee84ca6494bde37953012c9e3"
+checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
 dependencies = [
  "accesskit",
  "ahash",
+ "emath",
  "epaint",
  "log",
  "nohash-hasher",
@@ -908,7 +928,7 @@ dependencies = [
  "gpu-allocator",
  "image",
  "log",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "ron",
  "serde",
  "tobj",
@@ -916,16 +936,17 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d95d9762056c541bd2724de02910d8bccf3af8e37689dc114b21730e64f80a0"
+checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
 dependencies = [
  "accesskit_winit",
+ "ahash",
  "arboard",
  "egui",
  "log",
  "puffin",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "serde",
  "smithay-clipboard",
  "web-time",
@@ -935,10 +956,11 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753c36d3e2f7a32425af5290af2e52efb3471ea3a263b87f003b5433351b0fd7"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
 dependencies = [
+ "ahash",
  "egui",
  "ehttp",
  "enum-map",
@@ -951,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "egui_tiles"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0255c0209b349b1a4a67a344556501e75accae669f3a25be6e07deb30fefa91"
+checksum = "269227b10b417e635dc71a2d7350db1721386a3a4098c9855e5a2fe57092cea5"
 dependencies = [
  "ahash",
  "egui",
@@ -964,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "ehttp"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88f45662356f96afc7d9e2bc9910ad8352ee01417f7c69b8b16a53c8767a75d"
+checksum = "59a81c221a1e4dad06cb9c9deb19aea1193a5eea084e8cd42d869068132bf876"
 dependencies = [
  "document-features",
  "js-sys",
@@ -978,15 +1000,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee58355767587db7ba3738930d93cad3052cd834c2b48b9ef6ef26fe4823b7e"
+checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1010,14 +1032,14 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -1025,31 +1047,31 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
+checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "epaint"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e638cb066bff0903bbb6143116cfd134a42279c7d68f19c0352a94f15a402de7"
+checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1059,6 +1081,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "puffin",
  "serde",
 ]
 
@@ -1070,9 +1093,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1080,13 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "event-listener"
@@ -1107,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1118,11 +1137,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1137,24 +1156,24 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1184,7 +1203,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1204,15 +1223,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -1231,11 +1250,11 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.1",
+ "fastrand 2.1.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1244,21 +1263,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1282,16 +1301,6 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
@@ -1302,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1312,16 +1321,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.25.0"
+name = "gif"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
 
 [[package]]
 name = "gpu-allocator"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "ash",
  "log",
@@ -1331,15 +1350,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1349,11 +1374,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1379,17 +1404,18 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.7"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "jpeg-decoder",
- "num-rational",
+ "gif",
  "num-traits",
  "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1400,9 +1426,9 @@ checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1410,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1423,16 +1449,16 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1461,24 +1487,18 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
-
-[[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1494,29 +1514,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "redox_syscall 0.4.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1525,9 +1534,19 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
 ]
 
 [[package]]
@@ -1538,21 +1557,21 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litrs"
-version = "0.2.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9275e0933cf8bb20f008924c0cb07a0692fe54d8064996520bf998de9eb79aa"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1560,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "malloc_buf"
@@ -1575,15 +1594,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -1593,6 +1612,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1614,16 +1642,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -1635,13 +1657,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "jni-sys",
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -1669,7 +1690,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -1679,41 +1700,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1733,10 +1723,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1749,17 +1739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,9 +1746,9 @@ checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
 name = "objc-sys"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
@@ -1788,8 +1767,58 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
- "objc-sys 0.3.2",
+ "objc-sys 0.3.5",
  "objc2-encode 3.0.0",
+]
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys 0.3.5",
+ "objc2-encode 4.0.3",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1808,19 +1837,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
+name = "objc2-encode"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "objc",
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "orbclient"
@@ -1843,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.20.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
+checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
 dependencies = [
  "ttf-parser",
 ]
@@ -1858,9 +1921,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1868,22 +1931,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1899,9 +1962,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1911,26 +1974,26 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.1",
+ "fastrand 2.1.0",
  "futures-io",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "png"
-version = "0.17.10"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -1957,14 +2020,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.26",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1988,44 +2052,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "puffin"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b84517b2fb755da3a634bc030fcbc7b6337a786aa25a7fb350cdd51ab5e15"
+checksum = "b9f76ad4bb049fded4e572df72cbb6381ff5d1f41f85c3a04b56e4eca287a02f"
 dependencies = [
  "anyhow",
  "byteorder",
  "cfg-if",
  "once_cell",
+ "parking_lot",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2062,26 +2136,20 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "raw-window-metal"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4ea493258d54c24cb46aa9345d099e58e2ea3f30dd63667fc54fc892f18e76"
+checksum = "76e8caa82e31bb98fee12fa8f051c94a6aa36b07cddb03f0d4fc558988360ff1"
 dependencies = [
  "cocoa",
  "core-graphics",
  "objc",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
 ]
 
 [[package]]
@@ -2109,21 +2177,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.4"
+name = "redox_syscall"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
- "libredox 0.0.1",
+ "libredox 0.1.3",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2133,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2144,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "resvg"
@@ -2164,25 +2241,26 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.37"
+version = "0.8.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+checksum = "ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.6"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2191,8 +2269,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
- "bitflags 2.4.1",
+ "base64 0.21.7",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
@@ -2219,36 +2297,46 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2274,57 +2362,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sctk-adwaita"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
+checksum = "70b31447ca297092c5a9916fc3b955203157b37c19ca8edde4f52e9843e602c7"
 dependencies = [
  "ab_glyph",
  "log",
  "memmap2",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.18.1",
  "tiny-skia",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2340,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2379,51 +2457,76 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
+checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
- "bitflags 2.4.1",
- "calloop",
- "calloop-wayland-source",
+ "bitflags 2.6.0",
+ "calloop 0.12.4",
+ "calloop-wayland-source 0.2.0",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.26",
+ "rustix 0.38.34",
  "thiserror",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.6.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.34",
+ "thiserror",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols 0.32.3",
+ "wayland-protocols-wlr 0.3.3",
  "wayland-scanner",
  "xkeysym",
 ]
 
 [[package]]
 name = "smithay-clipboard"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
 dependencies = [
  "libc",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2",
  "wayland-backend",
 ]
 
 [[package]]
 name = "smol_str"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -2451,12 +2554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2561,12 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svgtypes"
@@ -2488,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2499,42 +2602,41 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "redox_syscall 0.4.1",
- "rustix 0.38.26",
- "windows-sys 0.48.0",
+ "fastrand 2.1.0",
+ "rustix 0.38.34",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "tiny-skia"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a067b809476893fce6a254cf285850ff69c847e6cfbade6a20b655b6c7e80d"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2547,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de35e8a90052baaaf61f171680ac2f8e925a1e43ea9d2e3a00514772250e541"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2558,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2573,24 +2675,35 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tobj"
-version = "4.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b450e3ba06251ec4fc76917dafeaf55805ffb26dbf7d5500bfb9511ce63a0d1f"
+checksum = "c3bd4ba05f29e4c65b6c0c11a58b6465ffa820bac890d76ad407b4e81d8372e8"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2616,7 +2729,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2630,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+checksum = "8686b91785aff82828ed725225925b33b4fde44c4bb15876e5f7c832724c420a"
 
 [[package]]
 name = "typenum"
@@ -2642,10 +2755,11 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uds_windows"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
+ "memoffset 0.9.1",
  "tempfile",
  "winapi",
 ]
@@ -2661,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -2673,18 +2787,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "untrusted"
@@ -2694,25 +2808,25 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki",
+ "rustls-pki-types",
  "url",
  "webpki-roots",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2725,7 +2839,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b0a51b72ab80ca511d126b77feeeb4fb1e972764653e61feac30adc161a756"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "log",
  "pico-args",
  "usvg-parser",
@@ -2771,15 +2885,15 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2793,9 +2907,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2803,24 +2917,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2830,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2840,32 +2954,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
 dependencies = [
  "cc",
  "downcast-rs",
- "nix",
+ "rustix 0.38.34",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -2873,12 +2987,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.1"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
 dependencies = [
- "bitflags 2.4.1",
- "nix",
+ "bitflags 2.6.0",
+ "rustix 0.38.34",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -2889,29 +3003,41 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.0"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44aa20ae986659d6c77d64d808a046996a932aa763913864dc40c359ef7ad5b"
+checksum = "6ef9489a8df197ebf3a8ce8a7a7f0a2320035c3743f3c1bd0bdbccf07ce64f95"
 dependencies = [
- "nix",
+ "rustix 0.38.34",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
+dependencies = [
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2923,10 +3049,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-scanner",
 ]
 
@@ -2936,18 +3062,31 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.3",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.0"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
+checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2956,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
 dependencies = [
  "dlib",
  "log",
@@ -2968,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2978,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2988,26 +3127,36 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.12"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2391658b02c27719fc5a0a73d6e696285138e8b12fba9d4baa70451023c71"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
 dependencies = [
+ "block2 0.5.1",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc",
- "raw-window-handle 0.5.2",
+ "objc2 0.5.2",
+ "objc2-foundation",
  "url",
  "web-sys",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"
@@ -3027,20 +3176,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
-dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3106,7 +3246,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3141,17 +3281,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3168,9 +3309,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3186,9 +3327,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3204,9 +3345,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3222,9 +3369,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3240,9 +3387,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3258,9 +3405,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3276,22 +3423,22 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.29.9"
+version = "0.29.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2376dab13e09c01ad8b679f0dbc7038af4ec43d9a91344338e37bd686481550"
+checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "bytemuck",
- "calloop",
+ "calloop 0.12.4",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",
@@ -3307,33 +3454,32 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "redox_syscall 0.3.5",
- "rustix 0.38.26",
+ "rustix 0.38.34",
  "sctk-adwaita",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.18.1",
  "smol_str",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
- "x11rb 0.13.0",
+ "x11rb",
  "xkbcommon-dl",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.5.24"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0383266b19108dfc6314a56047aa545a1b4d1be60e799b4dbdd407b56402704b"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -3351,73 +3497,48 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
-dependencies = [
- "gethostname 0.3.0",
- "nix",
- "winapi",
- "winapi-wsapoll",
- "x11rb-protocol 0.12.0",
-]
-
-[[package]]
-name = "x11rb"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "as-raw-xcb-connection",
- "gethostname 0.4.3",
+ "gethostname",
  "libc",
  "libloading",
  "once_cell",
- "rustix 0.38.26",
- "x11rb-protocol 0.13.0",
+ "rustix 0.38.34",
+ "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
-dependencies = [
- "nix",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
-dependencies = [
- "nom",
-]
+checksum = "d491ee231a51ae64a5b762114c3ac2104b967aadba1de45c86ca42cf051513b7"
 
 [[package]]
 name = "xdg-home"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
 dependencies = [
- "nix",
- "winapi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "xkbcommon-dl"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "dlib",
  "log",
  "once_cell",
@@ -3426,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "xkeysym"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xmlwriter"
@@ -3438,9 +3559,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zbus"
-version = "3.14.1"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3479,11 +3600,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.14.1"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3493,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
  "serde",
  "static_assertions",
@@ -3504,29 +3625,50 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]
 name = "zvariant"
-version = "3.15.0"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -3538,11 +3680,11 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.0"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,24 +43,24 @@ x11 = ["egui-winit/x11"]
 
 [dependencies]
 anyhow = "1.0.75"
-ash = { version = "0.37.3", default-features = false }
-ash-window = "0.12.0"
+ash = { version = "0.38.0", default-features = false }
+ash-window = "0.13.0"
 bytemuck = "1.14.0"
 directories-next = { version = "2.0.0", optional = true }
-egui = "0.25.0"
-egui-winit = "0.25.0"
-gpu-allocator = { version = "0.25.0", default-features = false, features = ["vulkan"], optional = true }
+egui = "0.28.1"
+egui-winit = "0.28.1"
+gpu-allocator = { version = "0.27.0", default-features = false, features = ["vulkan"], optional = true }
 log = "0.4.20"
-raw-window-handle = "0.5"
+raw-window-handle = "0.6.2"
 ron = { version = "0.8.1", optional = true }
 serde = { version = "1.0.193", optional = true }
 
 [dev-dependencies]
-ash = { version = "0.37.3", default-features = false, features = ["linked", "debug"] }
-egui_extras = { version = "0.25.0", features = ["all_loaders"] }
+ash = { version = "0.38.0", default-features = false, features = ["linked", "debug"] }
+egui_extras = { version = "0.28.1", features = ["all_loaders"] }
 egui-ash = { path = ".", features = ["gpu-allocator", "persistence"] }
-egui_tiles = "0.6.0"
-glam = "0.25.0"
-image = { version = "0.24.7", default-features = false, features = ["png", "jpeg", "bmp"] }
+egui_tiles = "0.9.0"
+glam = "0.28.0"
+image = { version = "0.25.1", default-features = false, features = ["png", "jpeg", "bmp"] }
 log = "0.4.20"
 tobj = "4.0.0"

--- a/examples/egui_ash_simple/main.rs
+++ b/examples/egui_ash_simple/main.rs
@@ -1,13 +1,7 @@
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
-};
+use ash::{vk, Device, Entry, Instance};
 use egui::FontData;
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
+    raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _},
     winit, App, AppCreator, AshRenderState, CreationContext, ExitSignal, RunOption, Theme,
 };
 use gpu_allocator::vulkan::*;
@@ -23,9 +17,9 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: ash::ext::debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Surface,
+    surface_loader: ash::khr::surface::Instance,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
@@ -73,7 +67,7 @@ impl App for MyApp {
             egui::Window::new("My Window")
                 .id(egui::Id::new("my_window"))
                 .resizable(true)
-                .scroll2([true, true])
+                .scroll([true, true])
                 .show(&ctx, |ui| {
                     ui.heading("Hello");
                     ui.label("Hello egui!");
@@ -158,14 +152,18 @@ impl MyAppCreator {
     }
 
     fn create_entry() -> Entry {
-        Entry::linked()
+        ash::Entry::linked()
     }
 
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (
+        Instance,
+        ash::ext::debug_utils::Instance,
+        vk::DebugUtilsMessengerEXT,
+    ) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -178,15 +176,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![ash::ext::debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -199,7 +196,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -215,7 +212,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = ash::ext::debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -229,12 +226,15 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> ash::khr::surface::Instance {
+        ash::khr::surface::Instance::new(entry, instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(
+        instance: &Instance,
+        device: &Device,
+    ) -> ash::khr::swapchain::Device {
+        ash::khr::swapchain::Device::new(instance, device)
     }
 
     fn create_surface(
@@ -246,8 +246,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Unable to get display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Unable to get display handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -256,7 +262,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &ash::khr::surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -358,13 +364,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -372,7 +377,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -391,7 +396,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {

--- a/examples/egui_ash_vulkan/renderer.rs
+++ b/examples/egui_ash_vulkan/renderer.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::khr::{Surface, Swapchain},
-    vk, Device,
-};
+use ash::{vk, Device};
 use egui_ash::EguiCommand;
 use glam::{Mat4, Vec3};
 use gpu_allocator::vulkan::{Allocation, Allocator};
@@ -34,27 +31,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -73,8 +67,8 @@ struct RendererInner {
 
     physical_device: vk::PhysicalDevice,
     device: Device,
-    surface_loader: Surface,
-    swapchain_loader: Swapchain,
+    surface_loader: ash::khr::surface::Instance,
+    swapchain_loader: ash::khr::swapchain::Device,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
@@ -108,8 +102,8 @@ struct RendererInner {
 impl RendererInner {
     fn create_swapchain(
         physical_device: vk::PhysicalDevice,
-        surface_loader: &ash::extensions::khr::Surface,
-        swapchain_loader: &ash::extensions::khr::Swapchain,
+        surface_loader: &ash::khr::surface::Instance,
+        swapchain_loader: &ash::khr::swapchain::Device,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
         width: u32,
@@ -161,7 +155,7 @@ impl RendererInner {
         let image_sharing_mode = vk::SharingMode::EXCLUSIVE;
         let queue_family_indices = [queue_family_index];
 
-        let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+        let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
             .surface(surface)
             .min_image_count(image_count)
             .image_format(surface_format.format)
@@ -198,7 +192,7 @@ impl RendererInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -240,10 +234,10 @@ impl RendererInner {
     }
 
     fn create_descriptor_pool(device: &Device, swapchain_count: usize) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(swapchain_count as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(swapchain_count as u32);
         unsafe {
@@ -257,12 +251,12 @@ impl RendererInner {
         device: &Device,
         swapchain_count: usize,
     ) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..swapchain_count)
@@ -280,7 +274,7 @@ impl RendererInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -289,11 +283,11 @@ impl RendererInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -308,7 +302,7 @@ impl RendererInner {
 
     fn create_render_pass(device: &Device, surface_format: vk::SurfaceFormatKHR) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(surface_format.format)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -316,9 +310,8 @@ impl RendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -326,24 +319,41 @@ impl RendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let dependencies = [
+            vk::SubpassDependency::default()
+                .src_subpass(vk::SUBPASS_EXTERNAL)
+                .dst_subpass(0)
+                .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+                .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+                .src_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
+                .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE),
+            vk::SubpassDependency::default()
+                .src_subpass(vk::SUBPASS_EXTERNAL)
+                .dst_subpass(0)
+                .src_stage_mask(vk::PipelineStageFlags::LATE_FRAGMENT_TESTS)
+                .dst_stage_mask(vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS)
+                .src_access_mask(vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE)
+                .dst_access_mask(
+                    vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ
+                        | vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ),
+        ];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
-            .subpasses(&subpasses);
+            .subpasses(&subpasses)
+            .dependencies(&dependencies);
         unsafe {
             device
                 .create_render_pass(&render_pass_create_info, None)
@@ -374,18 +384,17 @@ impl RendererInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(format.format)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -393,7 +402,7 @@ impl RendererInner {
             };
             attachments.push(color_attachment);
             color_image_views.push(color_attachment);
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -434,18 +443,17 @@ impl RendererInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -456,7 +464,7 @@ impl RendererInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(extent.width)
@@ -483,7 +491,7 @@ impl RendererInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -492,7 +500,7 @@ impl RendererInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -501,33 +509,31 @@ impl RendererInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -535,36 +541,36 @@ impl RendererInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -641,7 +647,7 @@ impl RendererInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -676,7 +682,7 @@ impl RendererInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -710,7 +716,7 @@ impl RendererInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -722,7 +728,7 @@ impl RendererInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -730,11 +736,10 @@ impl RendererInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -743,7 +748,7 @@ impl RendererInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -774,7 +779,7 @@ impl RendererInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(swapchain_count as u32),
@@ -788,7 +793,7 @@ impl RendererInner {
         swapchain_count: usize,
     ) -> (Vec<vk::Fence>, Vec<vk::Semaphore>, Vec<vk::Semaphore>) {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..swapchain_count {
             let fence = unsafe {
@@ -800,7 +805,7 @@ impl RendererInner {
         }
         let mut image_available_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -810,7 +815,7 @@ impl RendererInner {
         }
         let mut render_finished_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -909,7 +914,7 @@ impl RendererInner {
                 image_count
             };
 
-            let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+            let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
                 .surface(self.surface)
                 .min_image_count(image_count)
                 .image_color_space(surface_format.color_space)
@@ -977,8 +982,8 @@ impl RendererInner {
     fn new(
         physical_device: vk::PhysicalDevice,
         device: Device,
-        surface_loader: Surface,
-        swapchain_loader: Swapchain,
+        surface_loader: ash::khr::surface::Instance,
+        swapchain_loader: ash::khr::swapchain::Device,
         allocator: Arc<Mutex<Allocator>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
@@ -1082,6 +1087,16 @@ impl RendererInner {
             self.recreate_swapchain(width, height, &mut egui_cmd);
         }
 
+        // Wait for the resources of this frame index to be completed on the GPU before requesting the next image.
+        unsafe {
+            self.device.wait_for_fences(
+                std::slice::from_ref(&self.in_flight_fences[self.current_frame]),
+                true,
+                u64::MAX,
+            )
+        }
+        .expect("Failed to wait for fences");
+
         let result = unsafe {
             self.swapchain_loader.acquire_next_image(
                 self.swapchain,
@@ -1098,15 +1113,6 @@ impl RendererInner {
             }
             Err(_) => return,
         };
-
-        unsafe {
-            self.device.wait_for_fences(
-                std::slice::from_ref(&self.in_flight_fences[self.current_frame]),
-                true,
-                u64::MAX,
-            )
-        }
-        .expect("Failed to wait for fences");
 
         unsafe {
             self.device.reset_fences(std::slice::from_ref(
@@ -1139,7 +1145,7 @@ impl RendererInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1151,15 +1157,10 @@ impl RendererInner {
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[index])
-                    .render_area(
-                        vk::Rect2D::builder()
-                            .offset(vk::Offset2D::builder().x(0).y(0).build())
-                            .extent(self.surface_extent)
-                            .build(),
-                    )
+                    .render_area(vk::Rect2D::default().extent(self.surface_extent))
                     .clear_values(&[
                         vk::ClearValue {
                             color: vk::ClearColorValue {
@@ -1184,7 +1185,7 @@ impl RendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(width as f32)
                         .height(height as f32)
                         .min_depth(0.0)
@@ -1194,11 +1195,7 @@ impl RendererInner {
             self.device.cmd_set_scissor(
                 self.command_buffers[self.current_frame],
                 0,
-                std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(vk::Offset2D::builder().build())
-                        .extent(self.surface_extent),
-                ),
+                std::slice::from_ref(&vk::Rect2D::default().extent(self.surface_extent)),
             );
             self.device.cmd_bind_descriptor_sets(
                 self.command_buffers[self.current_frame],
@@ -1234,7 +1231,7 @@ impl RendererInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder()
+        let submit_info = vk::SubmitInfo::default()
             .command_buffers(&buffers_to_submit)
             .wait_semaphores(std::slice::from_ref(
                 &self.image_available_semaphores[self.current_frame],
@@ -1254,7 +1251,7 @@ impl RendererInner {
         };
 
         let image_indices = [index as u32];
-        let present_info = vk::PresentInfoKHR::builder()
+        let present_info = vk::PresentInfoKHR::default()
             .wait_semaphores(std::slice::from_ref(
                 &self.render_finished_semaphores[self.current_frame],
             ))
@@ -1342,8 +1339,8 @@ impl Renderer {
     pub fn new(
         physical_device: vk::PhysicalDevice,
         device: Device,
-        surface_loader: Surface,
-        swapchain_loader: Swapchain,
+        surface_loader: ash::khr::surface::Instance,
+        swapchain_loader: ash::khr::swapchain::Device,
         allocator: Arc<Mutex<Allocator>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,

--- a/examples/images/main.rs
+++ b/examples/images/main.rs
@@ -1,14 +1,10 @@
 use ash::vk::DebugUtilsMessengerEXT;
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
+use egui_ash::{
+    raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _},
+    winit, App, AppCreator, AshRenderState, CreationContext, RunOption,
 };
-use egui_ash::{winit, App, AppCreator, AshRenderState, CreationContext, RunOption};
 use gpu_allocator::vulkan::*;
-use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use std::{
     collections::HashSet,
     ffi::CString,
@@ -20,11 +16,11 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Surface,
-    swapchain_loader: Swapchain,
+    surface_loader: ash::khr::surface::Instance,
+    swapchain_loader: ash::khr::swapchain::Device,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -91,14 +87,14 @@ impl MyAppCreator {
     }
 
     fn create_entry() -> Entry {
-        Entry::linked()
+        ash::Entry::linked()
     }
 
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (Instance, debug_utils::Instance, DebugUtilsMessengerEXT) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -111,15 +107,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -132,7 +127,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -148,7 +143,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -162,12 +157,15 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> ash::khr::surface::Instance {
+        ash::khr::surface::Instance::new(&entry, &instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(
+        instance: &Instance,
+        device: &Device,
+    ) -> ash::khr::swapchain::Device {
+        ash::khr::swapchain::Device::new(&instance, &device)
     }
 
     fn create_surface(
@@ -179,8 +177,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Failed to get display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Failed to get window handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -189,7 +193,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &ash::khr::surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -291,13 +295,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -305,7 +308,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -324,7 +327,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {

--- a/examples/multi_viewports/main.rs
+++ b/examples/multi_viewports/main.rs
@@ -1,10 +1,4 @@
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{
     event, App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption, Theme,
 };
@@ -25,11 +19,11 @@ struct MyApp {
     entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Arc<Surface>,
-    swapchain_loader: Arc<Swapchain>,
+    surface_loader: Arc<ash::khr::surface::Instance>,
+    swapchain_loader: Arc<ash::khr::swapchain::Device>,
 
     triangle_surface: vk::SurfaceKHR,
     model_surface: Option<vk::SurfaceKHR>,
@@ -76,7 +70,7 @@ impl App for MyApp {
         egui::Window::new("My Window")
             .id(egui::Id::new("my_window"))
             .resizable(true)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(&ctx, |ui| {
                 ui.heading("Multi viewports");
                 ui.label("Hello egui multi viewports!");
@@ -163,7 +157,7 @@ impl App for MyApp {
                         egui::Window::new("My Window")
                             .id(egui::Id::new("deferred-viewport-window"))
                             .resizable(true)
-                            .scroll2([true, true])
+                            .scroll([true, true])
                             .show(&ctx, |ui| {
                                 ui.heading("Deferred Viewport");
                                 ui.label("deferred viewport!");

--- a/examples/multi_viewports/model_renderer.rs
+++ b/examples/multi_viewports/model_renderer.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::khr::{Surface, Swapchain},
-    vk, Device,
-};
+use ash::{vk, Device};
 use egui_ash::EguiCommand;
 use glam::{Mat4, Vec3};
 use gpu_allocator::vulkan::{Allocation, Allocator};
@@ -34,27 +31,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -73,8 +67,8 @@ struct ModelRendererInner {
 
     physical_device: vk::PhysicalDevice,
     device: Arc<Device>,
-    surface_loader: Arc<Surface>,
-    swapchain_loader: Arc<Swapchain>,
+    surface_loader: Arc<ash::khr::surface::Instance>,
+    swapchain_loader: Arc<ash::khr::swapchain::Device>,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
@@ -108,8 +102,8 @@ struct ModelRendererInner {
 impl ModelRendererInner {
     fn create_swapchain(
         physical_device: vk::PhysicalDevice,
-        surface_loader: &ash::extensions::khr::Surface,
-        swapchain_loader: &ash::extensions::khr::Swapchain,
+        surface_loader: &ash::khr::surface::Instance,
+        swapchain_loader: &ash::khr::swapchain::Device,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
         width: u32,
@@ -161,7 +155,7 @@ impl ModelRendererInner {
         let image_sharing_mode = vk::SharingMode::EXCLUSIVE;
         let queue_family_indices = [queue_family_index];
 
-        let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+        let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
             .surface(surface)
             .min_image_count(image_count)
             .image_format(surface_format.format)
@@ -198,7 +192,7 @@ impl ModelRendererInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -240,10 +234,10 @@ impl ModelRendererInner {
     }
 
     fn create_descriptor_pool(device: &Device, swapchain_count: usize) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(swapchain_count as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(swapchain_count as u32);
         unsafe {
@@ -257,12 +251,12 @@ impl ModelRendererInner {
         device: &Device,
         swapchain_count: usize,
     ) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..swapchain_count)
@@ -280,7 +274,7 @@ impl ModelRendererInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -289,11 +283,11 @@ impl ModelRendererInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -308,7 +302,7 @@ impl ModelRendererInner {
 
     fn create_render_pass(device: &Device, surface_format: vk::SurfaceFormatKHR) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(surface_format.format)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -316,9 +310,8 @@ impl ModelRendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -326,24 +319,41 @@ impl ModelRendererInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let dependencies = [vk::SubpassDependency::default()
+            .src_subpass(vk::SUBPASS_EXTERNAL)
+            .dst_subpass(0)
+            .src_stage_mask(
+                vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
+                    | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+            )
+            .dst_stage_mask(
+                vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
+                    | vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS,
+            )
+            .src_access_mask(
+                vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+                    | vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            )
+            .dst_access_mask(
+                vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+                    | vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            )];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
-            .subpasses(&subpasses);
+            .subpasses(&subpasses)
+            .dependencies(&dependencies);
         unsafe {
             device
                 .create_render_pass(&render_pass_create_info, None)
@@ -374,18 +384,17 @@ impl ModelRendererInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(format.format)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -393,7 +402,7 @@ impl ModelRendererInner {
             };
             attachments.push(color_attachment);
             color_image_views.push(color_attachment);
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -434,18 +443,17 @@ impl ModelRendererInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -456,7 +464,7 @@ impl ModelRendererInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(extent.width)
@@ -483,7 +491,7 @@ impl ModelRendererInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -492,7 +500,7 @@ impl ModelRendererInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -501,33 +509,31 @@ impl ModelRendererInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -535,36 +541,36 @@ impl ModelRendererInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -641,7 +647,7 @@ impl ModelRendererInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -676,7 +682,7 @@ impl ModelRendererInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -710,7 +716,7 @@ impl ModelRendererInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -722,7 +728,7 @@ impl ModelRendererInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -730,11 +736,10 @@ impl ModelRendererInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -743,7 +748,7 @@ impl ModelRendererInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -774,7 +779,7 @@ impl ModelRendererInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(swapchain_count as u32),
@@ -788,7 +793,7 @@ impl ModelRendererInner {
         swapchain_count: usize,
     ) -> (Vec<vk::Fence>, Vec<vk::Semaphore>, Vec<vk::Semaphore>) {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..swapchain_count {
             let fence = unsafe {
@@ -800,7 +805,7 @@ impl ModelRendererInner {
         }
         let mut image_available_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -810,7 +815,7 @@ impl ModelRendererInner {
         }
         let mut render_finished_semaphores = vec![];
         for _ in 0..swapchain_count {
-            let semaphore_create_info = vk::SemaphoreCreateInfo::builder();
+            let semaphore_create_info = vk::SemaphoreCreateInfo::default();
             let semaphore = unsafe {
                 device
                     .create_semaphore(&semaphore_create_info, None)
@@ -909,7 +914,7 @@ impl ModelRendererInner {
                 image_count
             };
 
-            let swapchain_create_info = vk::SwapchainCreateInfoKHR::builder()
+            let swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
                 .surface(self.surface)
                 .min_image_count(image_count)
                 .image_color_space(surface_format.color_space)
@@ -977,8 +982,8 @@ impl ModelRendererInner {
     fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<ash::khr::surface::Instance>,
+        swapchain_loader: Arc<ash::khr::swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,
@@ -1134,7 +1139,7 @@ impl ModelRendererInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1146,15 +1151,10 @@ impl ModelRendererInner {
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[index])
-                    .render_area(
-                        vk::Rect2D::builder()
-                            .offset(vk::Offset2D::builder().x(0).y(0).build())
-                            .extent(self.surface_extent)
-                            .build(),
-                    )
+                    .render_area(vk::Rect2D::default().extent(self.surface_extent))
                     .clear_values(&[
                         vk::ClearValue {
                             color: vk::ClearColorValue {
@@ -1179,7 +1179,7 @@ impl ModelRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(width as f32)
                         .height(height as f32)
                         .min_depth(0.0)
@@ -1190,8 +1190,8 @@ impl ModelRendererInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(vk::Offset2D::builder().build())
+                    &vk::Rect2D::default()
+                        .offset(vk::Offset2D::default())
                         .extent(self.surface_extent),
                 ),
             );
@@ -1229,7 +1229,7 @@ impl ModelRendererInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder()
+        let submit_info = vk::SubmitInfo::default()
             .command_buffers(&buffers_to_submit)
             .wait_semaphores(std::slice::from_ref(
                 &self.image_available_semaphores[self.current_frame],
@@ -1249,7 +1249,7 @@ impl ModelRendererInner {
         };
 
         let image_indices = [index as u32];
-        let present_info = vk::PresentInfoKHR::builder()
+        let present_info = vk::PresentInfoKHR::default()
             .wait_semaphores(std::slice::from_ref(
                 &self.render_finished_semaphores[self.current_frame],
             ))
@@ -1337,8 +1337,8 @@ impl ModelRenderer {
     pub fn new(
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-        surface_loader: Arc<Surface>,
-        swapchain_loader: Arc<Swapchain>,
+        surface_loader: Arc<ash::khr::surface::Instance>,
+        swapchain_loader: Arc<ash::khr::swapchain::Device>,
         allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
         surface: vk::SurfaceKHR,
         queue_family_index: u32,

--- a/examples/native_image/main.rs
+++ b/examples/native_image/main.rs
@@ -1,12 +1,6 @@
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
+    raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _},
     winit, App, AppCreator, AshRenderState, CreationContext, RunOption, Theme,
 };
 use gpu_allocator::vulkan::*;
@@ -21,11 +15,11 @@ struct MyApp {
     entry: Entry,
     instance: Instance,
     device: Device,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
     physical_device: vk::PhysicalDevice,
-    surface_loader: Surface,
-    swapchain_loader: Swapchain,
+    surface_loader: ash::khr::surface::Instance,
+    swapchain_loader: ash::khr::swapchain::Device,
     surface: vk::SurfaceKHR,
     queue: vk::Queue,
     command_pool: vk::CommandPool,
@@ -50,7 +44,7 @@ impl App for MyApp {
             egui::Window::new("My Window")
                 .id(egui::Id::new("my_window"))
                 .resizable(true)
-                .scroll2([true, true])
+                .scroll([true, true])
                 .show(&ctx, |ui| {
                     ui.label("user texture");
                     ui.image(egui::load::SizedTexture::new(
@@ -119,14 +113,14 @@ impl MyAppCreator {
     }
 
     fn create_entry() -> Entry {
-        Entry::linked()
+        ash::Entry::linked()
     }
 
     fn create_instance(
         required_instance_extensions: &[CString],
         entry: &Entry,
-    ) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+    ) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+        let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
             .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
             .message_severity(
                 vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -139,15 +133,14 @@ impl MyAppCreator {
                     | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                     | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
             )
-            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback))
-            .build();
+            .pfn_user_callback(Some(Self::vulkan_debug_utils_callback));
 
         let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-        let app_info = vk::ApplicationInfo::builder()
+        let app_info = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(vk::make_api_version(1, 0, 0, 0))
             .api_version(vk::API_VERSION_1_0);
-        let mut extension_names = vec![DebugUtils::name().as_ptr()];
+        let mut extension_names = vec![debug_utils::NAME.as_ptr()];
         for ext in required_instance_extensions {
             let name = ext.as_ptr();
             extension_names.push(name);
@@ -160,7 +153,7 @@ impl MyAppCreator {
             .iter()
             .map(|l| l.as_ptr())
             .collect::<Vec<*const i8>>();
-        let instance_create_info = vk::InstanceCreateInfo::builder()
+        let instance_create_info = vk::InstanceCreateInfo::default()
             .push_next(&mut debug_utils_messenger_create_info)
             .application_info(&app_info)
             .enabled_extension_names(&extension_names);
@@ -176,7 +169,7 @@ impl MyAppCreator {
         };
 
         // setup debug utils
-        let debug_utils_loader = DebugUtils::new(&entry, &instance);
+        let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
         let debug_messenger = if Self::ENABLE_VALIDATION_LAYERS {
             unsafe {
                 debug_utils_loader
@@ -190,12 +183,15 @@ impl MyAppCreator {
         (instance, debug_utils_loader, debug_messenger)
     }
 
-    fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-        Surface::new(&entry, &instance)
+    fn create_surface_loader(entry: &Entry, instance: &Instance) -> ash::khr::surface::Instance {
+        ash::khr::surface::Instance::new(&entry, &instance)
     }
 
-    fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-        Swapchain::new(&instance, &device)
+    fn create_swapchain_loader(
+        instance: &Instance,
+        device: &Device,
+    ) -> ash::khr::swapchain::Device {
+        ash::khr::swapchain::Device::new(&instance, &device)
     }
 
     fn create_surface(
@@ -207,8 +203,14 @@ impl MyAppCreator {
             ash_window::create_surface(
                 entry,
                 instance,
-                window.raw_display_handle(),
-                window.raw_window_handle(),
+                window
+                    .display_handle()
+                    .expect("Failed to get a display handle")
+                    .as_raw(),
+                window
+                    .window_handle()
+                    .expect("Failed to get a window handle")
+                    .as_raw(),
                 None,
             )
             .expect("Failed to create surface")
@@ -217,7 +219,7 @@ impl MyAppCreator {
 
     fn create_physical_device(
         instance: &Instance,
-        surface_loader: &Surface,
+        surface_loader: &ash::khr::surface::Instance,
         surface: vk::SurfaceKHR,
         required_device_extensions: &[CString],
     ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -319,13 +321,12 @@ impl MyAppCreator {
     ) -> (Device, vk::Queue) {
         let queue_priorities = [1.0_f32];
         let mut queue_create_infos = vec![];
-        let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+        let queue_create_info = vk::DeviceQueueCreateInfo::default()
             .queue_family_index(queue_family_index)
-            .queue_priorities(&queue_priorities)
-            .build();
+            .queue_priorities(&queue_priorities);
         queue_create_infos.push(queue_create_info);
 
-        let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+        let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
         let enable_extension_names = required_device_extensions
             .iter()
@@ -333,7 +334,7 @@ impl MyAppCreator {
             .collect::<Vec<_>>();
 
         // device create info
-        let device_create_info = vk::DeviceCreateInfo::builder()
+        let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_features(&physical_device_features)
             .enabled_extension_names(&enable_extension_names);
@@ -352,7 +353,7 @@ impl MyAppCreator {
     }
 
     fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-        let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+        let command_pool_create_info = vk::CommandPoolCreateInfo::default()
             .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
             .queue_family_index(queue_family_index);
         unsafe {
@@ -381,7 +382,7 @@ impl MyAppCreator {
         let staging_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(image_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -420,7 +421,7 @@ impl MyAppCreator {
         let image = unsafe {
             device
                 .create_image(
-                    &vk::ImageCreateInfo::builder()
+                    &vk::ImageCreateInfo::default()
                         .image_type(vk::ImageType::TYPE_2D)
                         .format(format)
                         .extent(vk::Extent3D {
@@ -458,7 +459,7 @@ impl MyAppCreator {
         unsafe {
             let command = device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -469,7 +470,7 @@ impl MyAppCreator {
             device
                 .begin_command_buffer(
                     command,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -482,22 +483,20 @@ impl MyAppCreator {
                 vk::DependencyFlags::empty(),
                 &[],
                 &[],
-                &[vk::ImageMemoryBarrier::builder()
+                &[vk::ImageMemoryBarrier::default()
                     .src_access_mask(vk::AccessFlags::empty())
                     .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
                     .old_layout(vk::ImageLayout::UNDEFINED)
                     .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                     .image(image)
                     .subresource_range(
-                        vk::ImageSubresourceRange::builder()
+                        vk::ImageSubresourceRange::default()
                             .aspect_mask(vk::ImageAspectFlags::COLOR)
                             .base_mip_level(0)
                             .level_count(1)
                             .base_array_layer(0)
-                            .layer_count(1)
-                            .build(),
-                    )
-                    .build()],
+                            .layer_count(1),
+                    )],
             );
 
             // Copy data from buffer to image
@@ -506,14 +505,13 @@ impl MyAppCreator {
                 staging_buffer,
                 image,
                 vk::ImageLayout::TRANSFER_DST_OPTIMAL,
-                &[vk::BufferImageCopy::builder()
+                &[vk::BufferImageCopy::default()
                     .image_subresource(
-                        vk::ImageSubresourceLayers::builder()
+                        vk::ImageSubresourceLayers::default()
                             .aspect_mask(vk::ImageAspectFlags::COLOR)
                             .mip_level(0)
                             .base_array_layer(0)
-                            .layer_count(1)
-                            .build(),
+                            .layer_count(1),
                     )
                     .image_extent(vk::Extent3D {
                         width: image_width,
@@ -523,8 +521,7 @@ impl MyAppCreator {
                     .buffer_offset(0)
                     .buffer_image_height(0)
                     .buffer_row_length(0)
-                    .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
-                    .build()],
+                    .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })],
             );
 
             // Change image layout to shader read only optimal
@@ -535,22 +532,20 @@ impl MyAppCreator {
                 vk::DependencyFlags::empty(),
                 &[],
                 &[],
-                &[vk::ImageMemoryBarrier::builder()
+                &[vk::ImageMemoryBarrier::default()
                     .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
                     .dst_access_mask(vk::AccessFlags::SHADER_READ)
                     .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
                     .new_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                     .image(image)
                     .subresource_range(
-                        vk::ImageSubresourceRange::builder()
+                        vk::ImageSubresourceRange::default()
                             .aspect_mask(vk::ImageAspectFlags::COLOR)
                             .base_mip_level(0)
                             .level_count(1)
                             .base_array_layer(0)
-                            .layer_count(1)
-                            .build(),
-                    )
-                    .build()],
+                            .layer_count(1),
+                    )],
             );
 
             // End command
@@ -562,9 +557,7 @@ impl MyAppCreator {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder()
-                        .command_buffers(&[command])
-                        .build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[command])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit command buffer");
@@ -585,7 +578,7 @@ impl MyAppCreator {
         let image_view = unsafe {
             device
                 .create_image_view(
-                    &vk::ImageViewCreateInfo::builder()
+                    &vk::ImageViewCreateInfo::default()
                         .view_type(vk::ImageViewType::TYPE_2D)
                         .image(image)
                         .format(format)
@@ -609,7 +602,7 @@ impl MyAppCreator {
 
         let sampler = unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)

--- a/examples/scene_view/main.rs
+++ b/examples/scene_view/main.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::{ext::DebugUtils, khr::Surface},
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption};
 use gpu_allocator::vulkan::*;
 use std::{
@@ -19,9 +16,9 @@ struct MyApp {
     _entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Arc<Surface>,
+    surface_loader: Arc<ash::khr::surface::Instance>,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,
@@ -42,7 +39,7 @@ impl App for MyApp {
                 .id(egui::Id::new("scene-view-window"))
                 .open(&mut self.show_scene_view)
                 .resizable(true)
-                .scroll2([true, true])
+                .scroll([true, true])
                 .collapsible(false)
                 .default_size(egui::vec2(600.0, 300.0))
                 .show(&ctx, |ui| {

--- a/examples/scene_view/scene_view.rs
+++ b/examples/scene_view/scene_view.rs
@@ -32,27 +32,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -114,7 +111,7 @@ impl SceneViewInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -156,10 +153,10 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(Self::IN_FLIGHT_FRAMES as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(Self::IN_FLIGHT_FRAMES as u32);
         unsafe {
@@ -170,12 +167,12 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_set_layouts(device: &Device) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..Self::IN_FLIGHT_FRAMES)
@@ -193,7 +190,7 @@ impl SceneViewInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -202,11 +199,11 @@ impl SceneViewInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -221,40 +218,36 @@ impl SceneViewInner {
 
     fn create_render_pass(device: &Device) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
                 .store_op(vk::AttachmentStoreOp::STORE)
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
-                .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .initial_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
                 .store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
-                .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .initial_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -292,7 +285,7 @@ impl SceneViewInner {
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let mut attachments = vec![];
 
-            let color_image_create_info = vk::ImageCreateInfo::builder()
+            let color_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -333,18 +326,15 @@ impl SceneViewInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(color_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::R8G8B8A8_UNORM)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
-                                    .base_mip_level(0)
                                     .level_count(1)
-                                    .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -355,7 +345,7 @@ impl SceneViewInner {
             color_image_allocations.push(color_allocation);
             color_image_views.push(color_attachment);
 
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -396,18 +386,15 @@ impl SceneViewInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
-                                    .base_mip_level(0)
                                     .level_count(1)
-                                    .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -421,7 +408,7 @@ impl SceneViewInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(width)
@@ -435,7 +422,7 @@ impl SceneViewInner {
             let cmd = unsafe {
                 device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_pool(command_pool)
                             .level(vk::CommandBufferLevel::PRIMARY)
                             .command_buffer_count(1),
@@ -446,7 +433,7 @@ impl SceneViewInner {
                 device
                     .begin_command_buffer(
                         cmd,
-                        &vk::CommandBufferBeginInfo::builder()
+                        &vk::CommandBufferBeginInfo::default()
                             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                     )
                     .expect("Failed to begin command buffer");
@@ -463,13 +450,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
             unsafe {
                 device
@@ -478,7 +464,7 @@ impl SceneViewInner {
                 device
                     .queue_submit(
                         queue,
-                        &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                        &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                         vk::Fence::null(),
                     )
                     .expect("Failed to submit queue");
@@ -500,7 +486,7 @@ impl SceneViewInner {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -522,7 +508,7 @@ impl SceneViewInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -531,7 +517,7 @@ impl SceneViewInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -540,33 +526,31 @@ impl SceneViewInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -574,36 +558,36 @@ impl SceneViewInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -680,7 +664,7 @@ impl SceneViewInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -715,7 +699,7 @@ impl SceneViewInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -749,7 +733,7 @@ impl SceneViewInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -761,7 +745,7 @@ impl SceneViewInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -769,11 +753,10 @@ impl SceneViewInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -782,7 +765,7 @@ impl SceneViewInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -812,7 +795,7 @@ impl SceneViewInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(Self::IN_FLIGHT_FRAMES as u32),
@@ -823,7 +806,7 @@ impl SceneViewInner {
 
     fn create_sync_objects(device: &Device) -> Vec<vk::Fence> {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let fence = unsafe {
@@ -1055,7 +1038,7 @@ impl SceneViewInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1065,41 +1048,55 @@ impl SceneViewInner {
                 )
                 .expect("Failed to begin command buffer");
 
+            // Insert image layout transitions and memory barriers for the color and depth images.
             vkutils::insert_image_memory_barrier(
                 &self.device,
                 &self.command_buffers[self.current_frame],
                 &self.color_images[self.current_frame],
                 self.queue_family_index,
                 self.queue_family_index,
-                vk::AccessFlags::NONE,
+                vk::AccessFlags::SHADER_READ,
                 vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::FRAGMENT_SHADER,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
+            );
+            vkutils::insert_image_memory_barrier(
+                &self.device,
+                &self.command_buffers[self.current_frame],
+                &self.depth_images[self.current_frame],
+                self.queue_family_index,
+                self.queue_family_index,
+                vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                vk::ImageLayout::UNDEFINED,
+                vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+                vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+                vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS,
+                vk::ImageSubresourceRange::default()
+                    .aspect_mask(vk::ImageAspectFlags::DEPTH)
+                    .layer_count(1u32)
+                    .level_count(1u32),
             );
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[self.current_frame])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(*vk::Offset2D::builder().x(0).y(0))
-                            .extent(
-                                *vk::Extent2D::builder()
-                                    .width(self.width)
-                                    .height(self.height),
-                            )
-                            .build(),
+                        vk::Rect2D::default().extent(
+                            vk::Extent2D::default()
+                                .width(self.width)
+                                .height(self.height),
+                        ),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1125,7 +1122,7 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(self.width as f32)
                         .height(self.height as f32)
                         .min_depth(0.0)
@@ -1136,13 +1133,11 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(*vk::Offset2D::builder())
-                        .extent(
-                            *vk::Extent2D::builder()
-                                .width(self.width)
-                                .height(self.height),
-                        ),
+                    &vk::Rect2D::default().extent(
+                        vk::Extent2D::default()
+                            .width(self.width)
+                            .height(self.height),
+                    ),
                 ),
             );
             self.device.cmd_bind_descriptor_sets(
@@ -1183,13 +1178,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device
@@ -1198,7 +1192,7 @@ impl SceneViewInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&buffers_to_submit);
+        let submit_info = vk::SubmitInfo::default().command_buffers(&buffers_to_submit);
         unsafe {
             self.device
                 .queue_submit(

--- a/examples/scene_view/vkutils.rs
+++ b/examples/scene_view/vkutils.rs
@@ -1,12 +1,6 @@
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
+    raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _},
     winit,
 };
 use std::{collections::HashSet, ffi::CString};
@@ -40,14 +34,14 @@ unsafe extern "system" fn vulkan_debug_utils_callback(
 }
 
 pub fn create_entry() -> Entry {
-    Entry::linked()
+    ash::Entry::linked()
 }
 
 pub fn create_instance(
     required_instance_extensions: &[CString],
     entry: &Entry,
-) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -60,15 +54,14 @@ pub fn create_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
-        .pfn_user_callback(Some(vulkan_debug_utils_callback))
-        .build();
+        .pfn_user_callback(Some(vulkan_debug_utils_callback));
 
     let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(1, 0, 0, 0))
         .api_version(vk::API_VERSION_1_0);
-    let mut extension_names = vec![DebugUtils::name().as_ptr()];
+    let mut extension_names = vec![debug_utils::NAME.as_ptr()];
     for ext in required_instance_extensions {
         let name = ext.as_ptr();
         extension_names.push(name);
@@ -81,7 +74,7 @@ pub fn create_instance(
         .iter()
         .map(|l| l.as_ptr())
         .collect::<Vec<*const i8>>();
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
@@ -97,7 +90,7 @@ pub fn create_instance(
     };
 
     // setup debug utils
-    let debug_utils_loader = DebugUtils::new(&entry, &instance);
+    let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
     let debug_messenger = if ENABLE_VALIDATION_LAYERS {
         unsafe {
             debug_utils_loader
@@ -111,12 +104,15 @@ pub fn create_instance(
     (instance, debug_utils_loader, debug_messenger)
 }
 
-pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-    Surface::new(&entry, &instance)
+pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> ash::khr::surface::Instance {
+    ash::khr::surface::Instance::new(&entry, &instance)
 }
 
-pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-    Swapchain::new(&instance, &device)
+pub fn create_swapchain_loader(
+    instance: &Instance,
+    device: &Device,
+) -> ash::khr::swapchain::Device {
+    ash::khr::swapchain::Device::new(&instance, &device)
 }
 
 pub fn create_surface(
@@ -128,8 +124,14 @@ pub fn create_surface(
         ash_window::create_surface(
             entry,
             instance,
-            window.raw_display_handle(),
-            window.raw_window_handle(),
+            window
+                .display_handle()
+                .expect("Unable to get a display handle")
+                .as_raw(),
+            window
+                .window_handle()
+                .expect("Unable to get a window handle")
+                .as_raw(),
             None,
         )
         .expect("Failed to create surface")
@@ -138,7 +140,7 @@ pub fn create_surface(
 
 pub fn create_physical_device(
     instance: &Instance,
-    surface_loader: &Surface,
+    surface_loader: &ash::khr::surface::Instance,
     surface: vk::SurfaceKHR,
     required_device_extensions: &[CString],
 ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -234,13 +236,12 @@ pub fn create_device(
 ) -> (Device, vk::Queue) {
     let queue_priorities = [1.0_f32];
     let mut queue_create_infos = vec![];
-    let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
         .queue_family_index(queue_family_index)
-        .queue_priorities(&queue_priorities)
-        .build();
+        .queue_priorities(&queue_priorities);
     queue_create_infos.push(queue_create_info);
 
-    let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+    let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
     let enable_extension_names = required_device_extensions
         .iter()
@@ -248,7 +249,7 @@ pub fn create_device(
         .collect::<Vec<_>>();
 
     // device create info
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_features(&physical_device_features)
         .enabled_extension_names(&enable_extension_names);
@@ -267,7 +268,7 @@ pub fn create_device(
 }
 
 pub fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-    let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+    let command_pool_create_info = vk::CommandPoolCreateInfo::default()
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .queue_family_index(queue_family_index);
     unsafe {
@@ -291,7 +292,7 @@ pub fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
@@ -299,8 +300,7 @@ pub fn insert_image_memory_barrier(
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
         .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
             *cmd,

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::{ext::DebugUtils, khr::Surface},
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{App, AppCreator, AshRenderState, CreationContext, HandleRedraw, RunOption};
 use gpu_allocator::vulkan::*;
 use std::{
@@ -25,9 +22,9 @@ struct MyApp {
     _entry: Arc<Entry>,
     instance: Arc<Instance>,
     device: Arc<Device>,
-    debug_utils_loader: DebugUtils,
+    debug_utils_loader: debug_utils::Instance,
     debug_messenger: vk::DebugUtilsMessengerEXT,
-    surface_loader: Arc<Surface>,
+    surface_loader: Arc<ash::khr::surface::Instance>,
     surface: vk::SurfaceKHR,
     command_pool: vk::CommandPool,
     allocator: ManuallyDrop<Arc<Mutex<Allocator>>>,

--- a/examples/tiles/scene_view.rs
+++ b/examples/tiles/scene_view.rs
@@ -32,27 +32,24 @@ struct Vertex {
 }
 impl Vertex {
     fn get_binding_descriptions() -> [vk::VertexInputBindingDescription; 1] {
-        [vk::VertexInputBindingDescription::builder()
+        [vk::VertexInputBindingDescription::default()
             .binding(0)
             .stride(std::mem::size_of::<Self>() as u32)
-            .input_rate(vk::VertexInputRate::VERTEX)
-            .build()]
+            .input_rate(vk::VertexInputRate::VERTEX)]
     }
 
     fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 2] {
         [
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(0)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(0)
-                .build(),
-            vk::VertexInputAttributeDescription::builder()
+                .offset(0),
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .location(1)
                 .format(vk::Format::R32G32B32_SFLOAT)
-                .offset(4 * 3)
-                .build(),
+                .offset(4 * 3),
         ]
     }
 }
@@ -121,7 +118,7 @@ impl SceneViewInner {
     ) -> (Vec<vk::Buffer>, Vec<Allocation>) {
         let buffer_size = std::mem::size_of::<UniformBufferObject>() as u64;
         let buffer_usage = vk::BufferUsageFlags::UNIFORM_BUFFER;
-        let buffer_create_info = vk::BufferCreateInfo::builder()
+        let buffer_create_info = vk::BufferCreateInfo::default()
             .size(buffer_size)
             .usage(buffer_usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE);
@@ -163,10 +160,10 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
-        let pool_size = vk::DescriptorPoolSize::builder()
+        let pool_size = vk::DescriptorPoolSize::default()
             .ty(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(Self::IN_FLIGHT_FRAMES as u32);
-        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::builder()
+        let descriptor_pool_create_info = vk::DescriptorPoolCreateInfo::default()
             .pool_sizes(std::slice::from_ref(&pool_size))
             .max_sets(Self::IN_FLIGHT_FRAMES as u32);
         unsafe {
@@ -177,12 +174,12 @@ impl SceneViewInner {
     }
 
     fn create_descriptor_set_layouts(device: &Device) -> Vec<vk::DescriptorSetLayout> {
-        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::builder()
+        let ubo_layout_binding = vk::DescriptorSetLayoutBinding::default()
             .binding(0)
             .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
             .descriptor_count(1)
             .stage_flags(vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT);
-        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::builder()
+        let ubo_layout_create_info = vk::DescriptorSetLayoutCreateInfo::default()
             .bindings(std::slice::from_ref(&ubo_layout_binding));
 
         (0..Self::IN_FLIGHT_FRAMES)
@@ -200,7 +197,7 @@ impl SceneViewInner {
         descriptor_set_layouts: &[vk::DescriptorSetLayout],
         uniform_buffers: &Vec<vk::Buffer>,
     ) -> Vec<vk::DescriptorSet> {
-        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::builder()
+        let descriptor_set_allocate_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(descriptor_pool)
             .set_layouts(descriptor_set_layouts);
         let descriptor_sets = unsafe {
@@ -209,11 +206,11 @@ impl SceneViewInner {
                 .expect("Failed to allocate descriptor sets")
         };
         for index in 0..descriptor_sets.len() {
-            let buffer_info = vk::DescriptorBufferInfo::builder()
+            let buffer_info = vk::DescriptorBufferInfo::default()
                 .buffer(uniform_buffers[index])
                 .offset(0)
                 .range(vk::WHOLE_SIZE);
-            let descriptor_write = vk::WriteDescriptorSet::builder()
+            let descriptor_write = vk::WriteDescriptorSet::default()
                 .dst_set(descriptor_sets[index])
                 .dst_binding(0)
                 .descriptor_type(vk::DescriptorType::UNIFORM_BUFFER)
@@ -228,7 +225,7 @@ impl SceneViewInner {
 
     fn create_render_pass(device: &Device) -> vk::RenderPass {
         let attachments = [
-            vk::AttachmentDescription::builder()
+            vk::AttachmentDescription::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -236,9 +233,8 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                .build(),
-            vk::AttachmentDescription::builder()
+                .final_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+            vk::AttachmentDescription::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .load_op(vk::AttachmentLoadOp::CLEAR)
@@ -246,22 +242,19 @@ impl SceneViewInner {
                 .stencil_load_op(vk::AttachmentLoadOp::DONT_CARE)
                 .stencil_store_op(vk::AttachmentStoreOp::DONT_CARE)
                 .initial_layout(vk::ImageLayout::UNDEFINED)
-                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                .build(),
+                .final_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
         ];
-        let color_reference = [vk::AttachmentReference::builder()
+        let color_reference = [vk::AttachmentReference::default()
             .attachment(0)
-            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-            .build()];
-        let depth_reference = vk::AttachmentReference::builder()
+            .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)];
+        let depth_reference = vk::AttachmentReference::default()
             .attachment(1)
             .layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        let subpasses = [vk::SubpassDescription::builder()
+        let subpasses = [vk::SubpassDescription::default()
             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
             .color_attachments(&color_reference)
-            .depth_stencil_attachment(&depth_reference)
-            .build()];
-        let render_pass_create_info = vk::RenderPassCreateInfo::builder()
+            .depth_stencil_attachment(&depth_reference)];
+        let render_pass_create_info = vk::RenderPassCreateInfo::default()
             .attachments(&attachments)
             .subpasses(&subpasses);
         unsafe {
@@ -299,7 +292,7 @@ impl SceneViewInner {
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let mut attachments = vec![];
 
-            let color_image_create_info = vk::ImageCreateInfo::builder()
+            let color_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::R8G8B8A8_UNORM)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -340,18 +333,17 @@ impl SceneViewInner {
             let color_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(color_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::R8G8B8A8_UNORM)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -362,7 +354,7 @@ impl SceneViewInner {
             color_image_allocations.push(color_allocation);
             color_image_views.push(color_attachment);
 
-            let depth_image_create_info = vk::ImageCreateInfo::builder()
+            let depth_image_create_info = vk::ImageCreateInfo::default()
                 .format(vk::Format::D32_SFLOAT)
                 .samples(vk::SampleCountFlags::TYPE_1)
                 .mip_levels(1)
@@ -403,18 +395,17 @@ impl SceneViewInner {
             let depth_attachment = unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(depth_image)
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(vk::Format::D32_SFLOAT)
                             .subresource_range(
-                                vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::DEPTH)
                                     .base_mip_level(0)
                                     .level_count(1)
                                     .base_array_layer(0)
-                                    .layer_count(1)
-                                    .build(),
+                                    .layer_count(1),
                             ),
                         None,
                     )
@@ -428,7 +419,7 @@ impl SceneViewInner {
             framebuffers.push(unsafe {
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments.as_slice())
                             .width(width)
@@ -442,7 +433,7 @@ impl SceneViewInner {
             let cmd = unsafe {
                 device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_pool(command_pool)
                             .level(vk::CommandBufferLevel::PRIMARY)
                             .command_buffer_count(1),
@@ -453,7 +444,7 @@ impl SceneViewInner {
                 device
                     .begin_command_buffer(
                         cmd,
-                        &vk::CommandBufferBeginInfo::builder()
+                        &vk::CommandBufferBeginInfo::default()
                             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                     )
                     .expect("Failed to begin command buffer");
@@ -470,13 +461,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::TOP_OF_PIPE,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
             unsafe {
                 device
@@ -485,7 +475,7 @@ impl SceneViewInner {
                 device
                     .queue_submit(
                         queue,
-                        &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                        &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                         vk::Fence::null(),
                     )
                     .expect("Failed to submit queue");
@@ -507,7 +497,7 @@ impl SceneViewInner {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -529,7 +519,7 @@ impl SceneViewInner {
     ) -> (vk::Pipeline, vk::PipelineLayout) {
         let vertex_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.vert.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -538,7 +528,7 @@ impl SceneViewInner {
         };
         let fragment_shader_module = {
             let spirv = include_spirv!("./shaders/spv/model.frag.spv");
-            let shader_module_create_info = vk::ShaderModuleCreateInfo::builder().code(&spirv);
+            let shader_module_create_info = vk::ShaderModuleCreateInfo::default().code(&spirv);
             unsafe {
                 device
                     .create_shader_module(&shader_module_create_info, None)
@@ -547,33 +537,31 @@ impl SceneViewInner {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
-                    &vk::PipelineLayoutCreateInfo::builder().set_layouts(&descriptor_set_layouts),
+                    &vk::PipelineLayoutCreateInfo::default().set_layouts(&descriptor_set_layouts),
                     None,
                 )
                 .expect("Failed to create pipeline layout")
         };
         let vertex_input_binding = Vertex::get_binding_descriptions();
         let vertex_input_attribute = Vertex::get_attribute_descriptions();
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -581,36 +569,36 @@ impl SceneViewInner {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let stencil_op = vk::StencilOpState::builder()
+        let stencil_op = vk::StencilOpState::default()
             .fail_op(vk::StencilOp::KEEP)
             .pass_op(vk::StencilOp::KEEP)
             .compare_op(vk::CompareOp::ALWAYS);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(true)
             .depth_write_enable(true)
             .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL)
             .depth_bounds_test_enable(false)
             .stencil_test_enable(false)
-            .front(*stencil_op)
-            .back(*stencil_op);
-        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::builder()
+            .front(stencil_op)
+            .back(stencil_op);
+        let color_blend_attachment = vk::PipelineColorBlendAttachmentState::default()
             .color_write_mask(
                 vk::ColorComponentFlags::R
                     | vk::ColorComponentFlags::G
                     | vk::ColorComponentFlags::B
                     | vk::ColorComponentFlags::A,
             );
-        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::builder()
+        let color_blend_info = vk::PipelineColorBlendStateCreateInfo::default()
             .attachments(std::slice::from_ref(&color_blend_attachment));
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let vertex_input_state = vk::PipelineVertexInputStateCreateInfo::default()
             .vertex_attribute_descriptions(&vertex_input_attribute)
             .vertex_binding_descriptions(&vertex_input_binding);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::builder()
+        let pipeline_create_info = vk::GraphicsPipelineCreateInfo::default()
             .stages(&pipeline_shader_stages)
             .vertex_input_state(&vertex_input_state)
             .input_assembly_state(&input_assembly_info)
@@ -687,7 +675,7 @@ impl SceneViewInner {
         let temporary_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(vk::BufferUsageFlags::TRANSFER_SRC),
                     None,
@@ -722,7 +710,7 @@ impl SceneViewInner {
         let vertex_buffer = unsafe {
             device
                 .create_buffer(
-                    &vk::BufferCreateInfo::builder()
+                    &vk::BufferCreateInfo::default()
                         .size(vertex_buffer_size)
                         .usage(
                             vk::BufferUsageFlags::TRANSFER_DST
@@ -756,7 +744,7 @@ impl SceneViewInner {
         let cmd = unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(1),
@@ -768,7 +756,7 @@ impl SceneViewInner {
             device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .expect("Failed to begin command buffer");
@@ -776,11 +764,10 @@ impl SceneViewInner {
                 cmd,
                 temporary_buffer,
                 vertex_buffer,
-                &[vk::BufferCopy::builder()
+                &[vk::BufferCopy::default()
                     .src_offset(0)
                     .dst_offset(0)
-                    .size(vertex_buffer_size)
-                    .build()],
+                    .size(vertex_buffer_size)],
             );
             device
                 .end_command_buffer(cmd)
@@ -789,7 +776,7 @@ impl SceneViewInner {
             device
                 .queue_submit(
                     queue,
-                    &[vk::SubmitInfo::builder().command_buffers(&[cmd]).build()],
+                    &[vk::SubmitInfo::default().command_buffers(&[cmd])],
                     vk::Fence::null(),
                 )
                 .expect("Failed to submit queue");
@@ -819,7 +806,7 @@ impl SceneViewInner {
         unsafe {
             device
                 .allocate_command_buffers(
-                    &vk::CommandBufferAllocateInfo::builder()
+                    &vk::CommandBufferAllocateInfo::default()
                         .command_pool(command_pool)
                         .level(vk::CommandBufferLevel::PRIMARY)
                         .command_buffer_count(Self::IN_FLIGHT_FRAMES as u32),
@@ -830,7 +817,7 @@ impl SceneViewInner {
 
     fn create_sync_objects(device: &Device) -> Vec<vk::Fence> {
         let fence_create_info =
-            vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
         let mut in_flight_fences = vec![];
         for _ in 0..Self::IN_FLIGHT_FRAMES {
             let fence = unsafe {
@@ -1076,7 +1063,7 @@ impl SceneViewInner {
             ptr.copy_from_nonoverlapping([ubo].as_ptr(), 1);
         }
 
-        let command_buffer_begin_info = vk::CommandBufferBeginInfo::builder()
+        let command_buffer_begin_info = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         unsafe {
             self.device
@@ -1092,35 +1079,31 @@ impl SceneViewInner {
                 &self.color_images[self.current_frame],
                 self.queue_family_index,
                 self.queue_family_index,
-                vk::AccessFlags::NONE,
+                vk::AccessFlags::SHADER_READ,
                 vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::FRAGMENT_SHADER,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device.cmd_begin_render_pass(
                 self.command_buffers[self.current_frame],
-                &vk::RenderPassBeginInfo::builder()
+                &vk::RenderPassBeginInfo::default()
                     .render_pass(self.render_pass)
                     .framebuffer(self.framebuffers[self.current_frame])
                     .render_area(
-                        vk::Rect2D::builder()
-                            .offset(*vk::Offset2D::builder().x(0).y(0))
-                            .extent(
-                                *vk::Extent2D::builder()
-                                    .width(self.width)
-                                    .height(self.height),
-                            )
-                            .build(),
+                        vk::Rect2D::default().extent(
+                            vk::Extent2D::default()
+                                .width(self.width)
+                                .height(self.height),
+                        ),
                     )
                     .clear_values(&[
                         vk::ClearValue {
@@ -1151,7 +1134,7 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Viewport::builder()
+                    &vk::Viewport::default()
                         .width(self.width as f32)
                         .height(self.height as f32)
                         .min_depth(0.0)
@@ -1162,13 +1145,11 @@ impl SceneViewInner {
                 self.command_buffers[self.current_frame],
                 0,
                 std::slice::from_ref(
-                    &vk::Rect2D::builder()
-                        .offset(*vk::Offset2D::builder())
-                        .extent(
-                            *vk::Extent2D::builder()
-                                .width(self.width)
-                                .height(self.height),
-                        ),
+                    &vk::Rect2D::default().extent(
+                        vk::Extent2D::default()
+                            .width(self.width)
+                            .height(self.height),
+                    ),
                 ),
             );
             self.device.cmd_bind_descriptor_sets(
@@ -1209,13 +1190,12 @@ impl SceneViewInner {
                 vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
                 vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
                 vk::PipelineStageFlags::FRAGMENT_SHADER,
-                vk::ImageSubresourceRange::builder()
+                vk::ImageSubresourceRange::default()
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .base_array_layer(0u32)
                     .layer_count(1u32)
                     .base_mip_level(0u32)
-                    .level_count(1u32)
-                    .build(),
+                    .level_count(1u32),
             );
 
             self.device
@@ -1224,7 +1204,7 @@ impl SceneViewInner {
         }
 
         let buffers_to_submit = [self.command_buffers[self.current_frame]];
-        let submit_info = vk::SubmitInfo::builder().command_buffers(&buffers_to_submit);
+        let submit_info = vk::SubmitInfo::default().command_buffers(&buffers_to_submit);
         unsafe {
             self.device
                 .queue_submit(

--- a/examples/tiles/vkutils.rs
+++ b/examples/tiles/vkutils.rs
@@ -1,12 +1,6 @@
-use ash::{
-    extensions::{
-        ext::DebugUtils,
-        khr::{Surface, Swapchain},
-    },
-    vk, Device, Entry, Instance,
-};
+use ash::{ext::debug_utils, vk, Device, Entry, Instance};
 use egui_ash::{
-    raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle},
+    raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _},
     winit,
 };
 use std::{collections::HashSet, ffi::CString};
@@ -40,14 +34,14 @@ unsafe extern "system" fn vulkan_debug_utils_callback(
 }
 
 pub fn create_entry() -> Entry {
-    Entry::linked()
+    ash::Entry::linked()
 }
 
 pub fn create_instance(
     required_instance_extensions: &[CString],
     entry: &Entry,
-) -> (Instance, DebugUtils, vk::DebugUtilsMessengerEXT) {
-    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
+) -> (Instance, debug_utils::Instance, vk::DebugUtilsMessengerEXT) {
+    let mut debug_utils_messenger_create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
@@ -60,15 +54,14 @@ pub fn create_instance(
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION,
         )
-        .pfn_user_callback(Some(vulkan_debug_utils_callback))
-        .build();
+        .pfn_user_callback(Some(vulkan_debug_utils_callback));
 
     let app_name = std::ffi::CString::new("egui-ash example simple").unwrap();
-    let app_info = vk::ApplicationInfo::builder()
+    let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(1, 0, 0, 0))
         .api_version(vk::API_VERSION_1_0);
-    let mut extension_names = vec![DebugUtils::name().as_ptr()];
+    let mut extension_names = vec![debug_utils::NAME.as_ptr()];
     for ext in required_instance_extensions {
         let name = ext.as_ptr();
         extension_names.push(name);
@@ -81,7 +74,7 @@ pub fn create_instance(
         .iter()
         .map(|l| l.as_ptr())
         .collect::<Vec<*const i8>>();
-    let instance_create_info = vk::InstanceCreateInfo::builder()
+    let instance_create_info = vk::InstanceCreateInfo::default()
         .push_next(&mut debug_utils_messenger_create_info)
         .application_info(&app_info)
         .enabled_extension_names(&extension_names);
@@ -97,7 +90,7 @@ pub fn create_instance(
     };
 
     // setup debug utils
-    let debug_utils_loader = DebugUtils::new(&entry, &instance);
+    let debug_utils_loader = debug_utils::Instance::new(&entry, &instance);
     let debug_messenger = if ENABLE_VALIDATION_LAYERS {
         unsafe {
             debug_utils_loader
@@ -111,12 +104,15 @@ pub fn create_instance(
     (instance, debug_utils_loader, debug_messenger)
 }
 
-pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> Surface {
-    Surface::new(&entry, &instance)
+pub fn create_surface_loader(entry: &Entry, instance: &Instance) -> ash::khr::surface::Instance {
+    ash::khr::surface::Instance::new(&entry, &instance)
 }
 
-pub fn create_swapchain_loader(instance: &Instance, device: &Device) -> Swapchain {
-    Swapchain::new(&instance, &device)
+pub fn create_swapchain_loader(
+    instance: &Instance,
+    device: &Device,
+) -> ash::khr::swapchain::Device {
+    ash::khr::swapchain::Device::new(&instance, &device)
 }
 
 pub fn create_surface(
@@ -128,8 +124,14 @@ pub fn create_surface(
         ash_window::create_surface(
             entry,
             instance,
-            window.raw_display_handle(),
-            window.raw_window_handle(),
+            window
+                .display_handle()
+                .expect("Failed to get display handle")
+                .as_raw(),
+            window
+                .window_handle()
+                .expect("Failed to get window handle")
+                .as_raw(),
             None,
         )
         .expect("Failed to create surface")
@@ -138,7 +140,7 @@ pub fn create_surface(
 
 pub fn create_physical_device(
     instance: &Instance,
-    surface_loader: &Surface,
+    surface_loader: &ash::khr::surface::Instance,
     surface: vk::SurfaceKHR,
     required_device_extensions: &[CString],
 ) -> (vk::PhysicalDevice, vk::PhysicalDeviceMemoryProperties, u32) {
@@ -234,13 +236,12 @@ pub fn create_device(
 ) -> (Device, vk::Queue) {
     let queue_priorities = [1.0_f32];
     let mut queue_create_infos = vec![];
-    let queue_create_info = vk::DeviceQueueCreateInfo::builder()
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
         .queue_family_index(queue_family_index)
-        .queue_priorities(&queue_priorities)
-        .build();
+        .queue_priorities(&queue_priorities);
     queue_create_infos.push(queue_create_info);
 
-    let physical_device_features = vk::PhysicalDeviceFeatures::builder().build();
+    let physical_device_features = vk::PhysicalDeviceFeatures::default();
 
     let enable_extension_names = required_device_extensions
         .iter()
@@ -248,7 +249,7 @@ pub fn create_device(
         .collect::<Vec<_>>();
 
     // device create info
-    let device_create_info = vk::DeviceCreateInfo::builder()
+    let device_create_info = vk::DeviceCreateInfo::default()
         .queue_create_infos(&queue_create_infos)
         .enabled_features(&physical_device_features)
         .enabled_extension_names(&enable_extension_names);
@@ -267,7 +268,7 @@ pub fn create_device(
 }
 
 pub fn create_command_pool(device: &Device, queue_family_index: u32) -> vk::CommandPool {
-    let command_pool_create_info = vk::CommandPoolCreateInfo::builder()
+    let command_pool_create_info = vk::CommandPoolCreateInfo::default()
         .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
         .queue_family_index(queue_family_index);
     unsafe {
@@ -291,7 +292,7 @@ pub fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
@@ -299,8 +300,7 @@ pub fn insert_image_memory_barrier(
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
         .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
             *cmd,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,4 @@
-use ash::{
-    extensions::khr::{Surface, Swapchain},
-    vk, Device, Entry, Instance,
-};
+use ash::{vk, Device, Entry, Instance};
 use egui_winit::winit;
 use std::ffi::CString;
 
@@ -88,8 +85,8 @@ pub struct AshRenderState<A: Allocator + 'static> {
     pub instance: Instance,
     pub physical_device: vk::PhysicalDevice,
     pub device: Device,
-    pub surface_loader: Surface,
-    pub swapchain_loader: Swapchain,
+    pub surface_loader: ash::khr::surface::Instance,
+    pub swapchain_loader: ash::khr::swapchain::Device,
     pub queue: vk::Queue,
     pub queue_family_index: u32,
     pub command_pool: vk::CommandPool,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -53,9 +53,9 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     fn create_render_pass(device: &Device, surface_format: vk::Format) -> vk::RenderPass {
         unsafe {
             device.create_render_pass(
-                &vk::RenderPassCreateInfo::builder()
+                &vk::RenderPassCreateInfo::default()
                     .attachments(std::slice::from_ref(
-                        &vk::AttachmentDescription::builder()
+                        &vk::AttachmentDescription::default()
                             .format(surface_format)
                             .samples(vk::SampleCountFlags::TYPE_1)
                             .load_op(vk::AttachmentLoadOp::LOAD)
@@ -66,23 +66,21 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                             .final_layout(vk::ImageLayout::PRESENT_SRC_KHR),
                     ))
                     .subpasses(std::slice::from_ref(
-                        &vk::SubpassDescription::builder()
+                        &vk::SubpassDescription::default()
                             .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS)
                             .color_attachments(std::slice::from_ref(
-                                &vk::AttachmentReference::builder()
+                                &vk::AttachmentReference::default()
                                     .attachment(0)
                                     .layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
                             )),
                     ))
-                    .dependencies(std::slice::from_ref(
-                        &vk::SubpassDependency::builder()
-                            .src_subpass(vk::SUBPASS_EXTERNAL)
-                            .dst_subpass(0)
-                            .src_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
-                            .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
-                            .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
-                            .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT),
-                    )),
+                    .dependencies(&[vk::SubpassDependency::default()
+                        .src_subpass(vk::SUBPASS_EXTERNAL)
+                        .dst_subpass(0)
+                        .src_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
+                        .dst_access_mask(vk::AccessFlags::COLOR_ATTACHMENT_WRITE)
+                        .src_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)
+                        .dst_stage_mask(vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT)]),
                 None,
             )
         }
@@ -95,10 +93,10 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     ) -> vk::PipelineLayout {
         unsafe {
             device.create_pipeline_layout(
-                &vk::PipelineLayoutCreateInfo::builder()
+                &vk::PipelineLayoutCreateInfo::default()
                     .set_layouts(&[descriptor_set_layout])
                     .push_constant_ranges(std::slice::from_ref(
-                        &vk::PushConstantRange::builder()
+                        &vk::PushConstantRange::default()
                             .stage_flags(vk::ShaderStageFlags::VERTEX)
                             .offset(0)
                             .size(std::mem::size_of::<f32>() as u32 * 2),
@@ -116,26 +114,23 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
     ) -> vk::Pipeline {
         let attributes = [
             // position
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(0)
                 .location(0)
-                .format(vk::Format::R32G32_SFLOAT)
-                .build(),
+                .format(vk::Format::R32G32_SFLOAT),
             // uv
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(8)
                 .location(1)
-                .format(vk::Format::R32G32_SFLOAT)
-                .build(),
+                .format(vk::Format::R32G32_SFLOAT),
             // color
-            vk::VertexInputAttributeDescription::builder()
+            vk::VertexInputAttributeDescription::default()
                 .binding(0)
                 .offset(16)
                 .location(2)
-                .format(vk::Format::R8G8B8A8_UNORM)
-                .build(),
+                .format(vk::Format::R8G8B8A8_UNORM),
         ];
 
         let vertex_shader_module = {
@@ -160,24 +155,22 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
         };
         let main_function_name = CString::new("main").unwrap();
         let pipeline_shader_stages = [
-            vk::PipelineShaderStageCreateInfo::builder()
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::VERTEX)
                 .module(vertex_shader_module)
-                .name(&main_function_name)
-                .build(),
-            vk::PipelineShaderStageCreateInfo::builder()
+                .name(&main_function_name),
+            vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fragment_shader_module)
-                .name(&main_function_name)
-                .build(),
+                .name(&main_function_name),
         ];
 
-        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::builder()
+        let input_assembly_info = vk::PipelineInputAssemblyStateCreateInfo::default()
             .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-        let viewport_info = vk::PipelineViewportStateCreateInfo::builder()
+        let viewport_info = vk::PipelineViewportStateCreateInfo::default()
             .viewport_count(1)
             .scissor_count(1);
-        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::builder()
+        let rasterization_info = vk::PipelineRasterizationStateCreateInfo::default()
             .depth_clamp_enable(false)
             .rasterizer_discard_enable(false)
             .polygon_mode(vk::PolygonMode::FILL)
@@ -185,7 +178,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
             .depth_bias_enable(false)
             .line_width(1.0);
-        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::builder()
+        let depth_stencil_info = vk::PipelineDepthStencilStateCreateInfo::default()
             .depth_test_enable(false)
             .depth_write_enable(false)
             .depth_compare_op(vk::CompareOp::ALWAYS)
@@ -205,21 +198,21 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             });
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic_state_info =
-            vk::PipelineDynamicStateCreateInfo::builder().dynamic_states(&dynamic_states);
-        let multisample_info = vk::PipelineMultisampleStateCreateInfo::builder()
+            vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+        let multisample_info = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);
 
         let pipeline = unsafe {
             device.create_graphics_pipelines(
                 vk::PipelineCache::null(),
                 std::slice::from_ref(
-                    &vk::GraphicsPipelineCreateInfo::builder()
+                    &vk::GraphicsPipelineCreateInfo::default()
                         .stages(&pipeline_shader_stages)
                         .vertex_input_state(
-                            &vk::PipelineVertexInputStateCreateInfo::builder()
+                            &vk::PipelineVertexInputStateCreateInfo::default()
                                 .vertex_attribute_descriptions(&attributes)
                                 .vertex_binding_descriptions(std::slice::from_ref(
-                                    &vk::VertexInputBindingDescription::builder()
+                                    &vk::VertexInputBindingDescription::default()
                                         .binding(0)
                                         .input_rate(vk::VertexInputRate::VERTEX)
                                         .stride(
@@ -234,9 +227,9 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                         .multisample_state(&multisample_info)
                         .depth_stencil_state(&depth_stencil_info)
                         .color_blend_state(
-                            &vk::PipelineColorBlendStateCreateInfo::builder().attachments(
+                            &vk::PipelineColorBlendStateCreateInfo::default().attachments(
                                 std::slice::from_ref(
-                                    &vk::PipelineColorBlendAttachmentState::builder()
+                                    &vk::PipelineColorBlendAttachmentState::default()
                                         .color_write_mask(
                                             vk::ColorComponentFlags::R
                                                 | vk::ColorComponentFlags::G
@@ -280,12 +273,12 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             .map(|swapchain_image| unsafe {
                 device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .image(swapchain_image.clone())
                             .view_type(vk::ImageViewType::TYPE_2D)
                             .format(surface_format)
                             .subresource_range(
-                                *vk::ImageSubresourceRange::builder()
+                                vk::ImageSubresourceRange::default()
                                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                                     .base_mip_level(0)
                                     .level_count(1)
@@ -303,7 +296,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                 let attachments = &[image_views];
                 device
                     .create_framebuffer(
-                        &vk::FramebufferCreateInfo::builder()
+                        &vk::FramebufferCreateInfo::default()
                             .render_pass(render_pass)
                             .attachments(attachments)
                             .width(width)
@@ -336,7 +329,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             let vertex_buffer = unsafe {
                 device
                     .create_buffer(
-                        &vk::BufferCreateInfo::builder()
+                        &vk::BufferCreateInfo::default()
                             .usage(vk::BufferUsageFlags::VERTEX_BUFFER)
                             .sharing_mode(vk::SharingMode::EXCLUSIVE)
                             .size(Self::vertex_buffer_size()),
@@ -367,7 +360,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
             let index_buffer = unsafe {
                 device
                     .create_buffer(
-                        &vk::BufferCreateInfo::builder()
+                        &vk::BufferCreateInfo::default()
                             .usage(vk::BufferUsageFlags::INDEX_BUFFER)
                             .sharing_mode(vk::SharingMode::EXCLUSIVE)
                             .size(Self::index_buffer_size()),
@@ -581,13 +574,13 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                     unsafe {
                         this.device.cmd_begin_render_pass(
                             cmd,
-                            &vk::RenderPassBeginInfo::builder()
+                            &vk::RenderPassBeginInfo::default()
                                 .render_pass(state.render_pass)
                                 .framebuffer(state.framebuffers[index])
                                 .clear_values(&[])
                                 .render_area(
-                                    *vk::Rect2D::builder().extent(
-                                        *vk::Extent2D::builder()
+                                    vk::Rect2D::default().extent(
+                                        vk::Extent2D::default()
                                             .width(state.width)
                                             .height(state.height),
                                     ),
@@ -738,7 +731,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                                 cmd,
                                 0,
                                 std::slice::from_ref(
-                                    &vk::Rect2D::builder()
+                                    &vk::Rect2D::default()
                                         .offset(vk::Offset2D {
                                             x: min.x.round() as i32,
                                             y: min.y.round() as i32,
@@ -753,7 +746,7 @@ impl<A: Allocator + 'static> ViewportRenderer<A> {
                                 cmd,
                                 0,
                                 std::slice::from_ref(
-                                    &vk::Viewport::builder()
+                                    &vk::Viewport::default()
                                         .x(0.0)
                                         .y(0.0)
                                         .width(state.physical_width as f32)
@@ -849,7 +842,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
     fn create_sampler(device: &Device) -> vk::Sampler {
         unsafe {
             device.create_sampler(
-                &vk::SamplerCreateInfo::builder()
+                &vk::SamplerCreateInfo::default()
                     .address_mode_u(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_v(vk::SamplerAddressMode::CLAMP_TO_EDGE)
                     .address_mode_w(vk::SamplerAddressMode::CLAMP_TO_EDGE)
@@ -914,7 +907,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .create_command_pool(
-                        &vk::CommandPoolCreateInfo::builder()
+                        &vk::CommandPoolCreateInfo::default()
                             .queue_family_index(self.queue_family_index),
                         None,
                     )
@@ -925,7 +918,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .allocate_command_buffers(
-                        &vk::CommandBufferAllocateInfo::builder()
+                        &vk::CommandBufferAllocateInfo::default()
                             .command_buffer_count(1u32)
                             .command_pool(cmd_pool)
                             .level(vk::CommandBufferLevel::PRIMARY),
@@ -935,13 +928,13 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
         };
         let cmd_fence = unsafe {
             self.device
-                .create_fence(&vk::FenceCreateInfo::builder(), None)
+                .create_fence(&vk::FenceCreateInfo::default(), None)
                 .unwrap()
         };
 
         let (staging_buffer, staging_allocation) = {
             let buffer_size = data.len() as vk::DeviceSize;
-            let buffer_info = vk::BufferCreateInfo::builder()
+            let buffer_info = vk::BufferCreateInfo::default()
                 .size(buffer_size)
                 .usage(vk::BufferUsageFlags::TRANSFER_SRC);
             let texture_buffer = unsafe { self.device.create_buffer(&buffer_info, None) }.unwrap();
@@ -975,7 +968,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             };
             let handle = unsafe {
                 self.device.create_image(
-                    &vk::ImageCreateInfo::builder()
+                    &vk::ImageCreateInfo::default()
                         .array_layers(1)
                         .extent(extent)
                         .flags(vk::ImageCreateFlags::empty())
@@ -1016,7 +1009,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device
                     .create_image_view(
-                        &vk::ImageViewCreateInfo::builder()
+                        &vk::ImageViewCreateInfo::default()
                             .components(vk::ComponentMapping::default())
                             .flags(vk::ImageViewCreateFlags::empty())
                             .format(vk::Format::R8G8B8A8_UNORM)
@@ -1040,7 +1033,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             self.device
                 .begin_command_buffer(
                     cmd,
-                    &vk::CommandBufferBeginInfo::builder()
+                    &vk::CommandBufferBeginInfo::default()
                         .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                 )
                 .unwrap();
@@ -1048,8 +1041,8 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
         // Transition texture image for transfer dst
         utils::insert_image_memory_barrier(
             &self.device,
-            &cmd,
-            &texture_image,
+            cmd,
+            texture_image,
             vk::QUEUE_FAMILY_IGNORED,
             vk::QUEUE_FAMILY_IGNORED,
             vk::AccessFlags::NONE_KHR,
@@ -1073,7 +1066,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                 texture_image,
                 vk::ImageLayout::TRANSFER_DST_OPTIMAL,
                 std::slice::from_ref(
-                    &vk::BufferImageCopy::builder()
+                    &vk::BufferImageCopy::default()
                         .buffer_offset(0)
                         .buffer_row_length(delta.image.width() as u32)
                         .buffer_image_height(delta.image.height() as u32)
@@ -1094,8 +1087,8 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
         }
         utils::insert_image_memory_barrier(
             &self.device,
-            &cmd,
-            &texture_image,
+            cmd,
+            texture_image,
             vk::QUEUE_FAMILY_IGNORED,
             vk::QUEUE_FAMILY_IGNORED,
             vk::AccessFlags::TRANSFER_WRITE,
@@ -1121,7 +1114,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             self.device
                 .queue_submit(
                     self.queue,
-                    std::slice::from_ref(&vk::SubmitInfo::builder().command_buffers(&cmd_buffs)),
+                    std::slice::from_ref(&vk::SubmitInfo::default().command_buffers(&cmd_buffs)),
                     cmd_fence,
                 )
                 .unwrap();
@@ -1135,7 +1128,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
         if let Some(pos) = delta.pos {
             // Blit texture data to existing texture if delta pos exists (e.g. font changed)
             let existing_texture = self.texture_images.get(&texture_id);
-            if let Some(existing_texture) = existing_texture {
+            if let Some(&existing_texture) = existing_texture {
                 let extent = vk::Extent3D {
                     width: delta.image.width() as u32,
                     height: delta.image.height() as u32,
@@ -1151,7 +1144,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                     self.device
                         .begin_command_buffer(
                             cmd,
-                            &vk::CommandBufferBeginInfo::builder()
+                            &vk::CommandBufferBeginInfo::default()
                                 .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
                         )
                         .unwrap();
@@ -1159,8 +1152,8 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                     // Transition existing image for transfer dst
                     utils::insert_image_memory_barrier(
                         &self.device,
-                        &cmd,
-                        &existing_texture,
+                        cmd,
+                        existing_texture,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::AccessFlags::SHADER_READ,
@@ -1180,8 +1173,8 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                     // Transition new image for transfer src
                     utils::insert_image_memory_barrier(
                         &self.device,
-                        &cmd,
-                        &texture_image,
+                        cmd,
+                        texture_image,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::AccessFlags::SHADER_READ,
@@ -1236,7 +1229,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                         cmd,
                         texture_image,
                         vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
-                        *existing_texture,
+                        existing_texture,
                         vk::ImageLayout::TRANSFER_DST_OPTIMAL,
                         &[region],
                         vk::Filter::NEAREST,
@@ -1245,8 +1238,8 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                     // Transition existing image for shader read
                     utils::insert_image_memory_barrier(
                         &self.device,
-                        &cmd,
-                        &existing_texture,
+                        cmd,
+                        existing_texture,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::QUEUE_FAMILY_IGNORED,
                         vk::AccessFlags::TRANSFER_WRITE,
@@ -1269,7 +1262,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                         .queue_submit(
                             self.queue,
                             std::slice::from_ref(
-                                &vk::SubmitInfo::builder().command_buffers(&cmd_buffs),
+                                &vk::SubmitInfo::default().command_buffers(&cmd_buffs),
                             ),
                             cmd_fence,
                         )
@@ -1294,7 +1287,7 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
                 unsafe {
                     self.device
                         .allocate_descriptor_sets(
-                            &vk::DescriptorSetAllocateInfo::builder()
+                            &vk::DescriptorSetAllocateInfo::default()
                                 .descriptor_pool(self.descriptor_pool)
                                 .set_layouts(&[self.descriptor_set_layout]),
                         )
@@ -1304,13 +1297,13 @@ impl<A: Allocator + 'static> ManagedTextures<A> {
             unsafe {
                 self.device.update_descriptor_sets(
                     std::slice::from_ref(
-                        &vk::WriteDescriptorSet::builder()
+                        &vk::WriteDescriptorSet::default()
                             .dst_set(dsc_set)
                             .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                             .dst_array_element(0_u32)
                             .dst_binding(0_u32)
                             .image_info(std::slice::from_ref(
-                                &vk::DescriptorImageInfo::builder()
+                                &vk::DescriptorImageInfo::default()
                                     .image_view(texture_image_view)
                                     .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                                     .sampler(self.sampler),
@@ -1487,7 +1480,7 @@ impl UserTextures {
                     id,
                     self.device
                         .allocate_descriptor_sets(
-                            &vk::DescriptorSetAllocateInfo::builder()
+                            &vk::DescriptorSetAllocateInfo::default()
                                 .descriptor_pool(self.descriptor_pool)
                                 .set_layouts(&[self.descriptor_set_layout]),
                         )
@@ -1499,13 +1492,13 @@ impl UserTextures {
         unsafe {
             self.device.update_descriptor_sets(
                 std::slice::from_ref(
-                    &vk::WriteDescriptorSet::builder()
+                    &vk::WriteDescriptorSet::default()
                         .dst_set(*dsc_set)
                         .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                         .dst_array_element(0_u32)
                         .dst_binding(0_u32)
                         .image_info(std::slice::from_ref(
-                            &vk::DescriptorImageInfo::builder()
+                            &vk::DescriptorImageInfo::default()
                                 .image_view(image_view)
                                 .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                                 .sampler(sampler),
@@ -1571,11 +1564,11 @@ impl<A: Allocator + 'static> Renderer<A> {
     fn create_descriptor_pool(device: &Device) -> vk::DescriptorPool {
         unsafe {
             device.create_descriptor_pool(
-                &vk::DescriptorPoolCreateInfo::builder()
+                &vk::DescriptorPoolCreateInfo::default()
                     .flags(vk::DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET)
                     .max_sets(1024)
                     .pool_sizes(std::slice::from_ref(
-                        &vk::DescriptorPoolSize::builder()
+                        &vk::DescriptorPoolSize::default()
                             .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                             .descriptor_count(1024),
                     )),
@@ -1588,8 +1581,8 @@ impl<A: Allocator + 'static> Renderer<A> {
     fn create_descriptor_set_layout(device: &Device) -> vk::DescriptorSetLayout {
         unsafe {
             device.create_descriptor_set_layout(
-                &vk::DescriptorSetLayoutCreateInfo::builder().bindings(std::slice::from_ref(
-                    &vk::DescriptorSetLayoutBinding::builder()
+                &vk::DescriptorSetLayoutCreateInfo::default().bindings(std::slice::from_ref(
+                    &vk::DescriptorSetLayoutBinding::default()
                         .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                         .descriptor_count(1)
                         .binding(0)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,8 +3,8 @@ use egui_winit::winit::event_loop::EventLoopWindowTarget;
 
 pub(crate) fn insert_image_memory_barrier(
     device: &ash::Device,
-    cmd: &ash::vk::CommandBuffer,
-    image: &ash::vk::Image,
+    cmd: ash::vk::CommandBuffer,
+    image: ash::vk::Image,
     src_q_family_index: u32,
     dst_q_family_index: u32,
     src_access_mask: ash::vk::AccessFlags,
@@ -15,19 +15,18 @@ pub(crate) fn insert_image_memory_barrier(
     dst_stage_mask: ash::vk::PipelineStageFlags,
     subresource_range: ash::vk::ImageSubresourceRange,
 ) {
-    let image_memory_barrier = ash::vk::ImageMemoryBarrier::builder()
+    let image_memory_barrier = ash::vk::ImageMemoryBarrier::default()
         .src_queue_family_index(src_q_family_index)
         .dst_queue_family_index(dst_q_family_index)
         .src_access_mask(src_access_mask)
         .dst_access_mask(dst_access_mask)
         .old_layout(old_image_layout)
         .new_layout(new_image_layout)
-        .image(*image)
-        .subresource_range(subresource_range)
-        .build();
+        .image(image)
+        .subresource_range(subresource_range);
     unsafe {
         device.cmd_pipeline_barrier(
-            *cmd,
+            cmd,
             src_stage_mask,
             dst_stage_mask,
             ash::vk::DependencyFlags::BY_REGION,


### PR DESCRIPTION
I updated each crate to the latest available version.

I then used the [Vulkan Configurator](https://github.com/LunarG/VulkanTools/blob/main/vkconfig/README.md) to run the examples with different validation layers enabled and used that to help fix some existing issues.

(Replacement of #8 but will always point to this commit)