### PR TITLE
update extension_names for macOS

### DIFF
--- a/examples/common/vkutils.rs
+++ b/examples/common/vkutils.rs
@@ -66,10 +66,10 @@ pub fn create_instance(
         let name = ext.as_ptr();
         extension_names.push(name);
     }
-     #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
-        extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
-        extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+        extension_names.push(ash::khr::portability_enumeration::NAME.as_ptr());
+        extension_names.push(ash::khr::get_physical_device_properties2::NAME.as_ptr());
     }
     let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
         vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR

--- a/examples/egui_ash_simple/main.rs
+++ b/examples/egui_ash_simple/main.rs
@@ -191,8 +191,8 @@ impl MyAppCreator {
         }
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
-            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
-            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+            extension_names.push(ash::khr::portability_enumeration::NAME.as_ptr());
+            extension_names.push(ash::khr::get_physical_device_properties2::NAME.as_ptr());
         }
         let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
             vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR

--- a/examples/native_image/main.rs
+++ b/examples/native_image/main.rs
@@ -147,8 +147,8 @@ impl MyAppCreator {
         }
          #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
-            extension_names.push(vk::KhrPortabilityEnumerationFn::name().as_ptr());
-            extension_names.push(vk::KhrGetPhysicalDeviceProperties2Fn::name().as_ptr());
+            extension_names.push(ash::khr::portability_enumeration::NAME.as_ptr());
+            extension_names.push(ash::khr::get_physical_device_properties2::NAME.as_ptr());
         }
         let create_flags = if cfg!(any(target_os = "macos", target_os = "ios")) {
             vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR


### PR DESCRIPTION
**Changed:**
  - `examples/common/vkutils.rs`
  - `examples/egui_ash_simple/main.rs`
  - `examples/native_image/main.rs`

  In ash 0.38, `vk::KhrXxxFn::name()` was replaced with `ash::khr::xxx::NAME`.